### PR TITLE
fix keystore insertions

### DIFF
--- a/substrate-node/charts/substrate-node/templates/deployment.yaml
+++ b/substrate-node/charts/substrate-node/templates/deployment.yaml
@@ -94,7 +94,8 @@ spec:
             "insert",
             "--keystore-path=/keystore",
             "--key-type", "aura",
-            "--suri","/keys/aura"
+            "--suri","/keys/aura",
+            "--scheme=sr25519"
           ]
           volumeMounts:
             - name: keystore
@@ -112,7 +113,8 @@ spec:
             "insert",
             "--keystore-path=/keystore",
             "--key-type", "gran",
-            "--suri","/keys/grandpa"
+            "--suri","/keys/grandpa",
+            "--scheme=ed25519"
           ]
           volumeMounts:
             - name: keystore


### PR DESCRIPTION
By default, the command `key insert` uses sr25519 as a scheme to derive the public key. When inserting aura keys this is fine, but when we insert the grandpa key (ed25519) we need to explicity tell that it needs to be ed25519 encoded. To bad the official docs did not cover this :)