### PR TITLE
feat(pallet-tft-price): refactor and improvements

### DIFF
--- a/pallets/pallet-tft-price/src/lib.rs
+++ b/pallets/pallet-tft-price/src/lib.rs
@@ -135,7 +135,7 @@ decl_module! {
 
         fn offchain_worker(block_number: T::BlockNumber) {
             match Self::offchain_signed_tx(block_number) {
-                Ok(_) => debug::info!("price set"),
+                Ok(_) => debug::info!("offchain worker done."),
                 Err(err) => debug::info!("err: {:?}", err)
             }
         }

--- a/pallets/pallet-tft-price/src/lib.rs
+++ b/pallets/pallet-tft-price/src/lib.rs
@@ -3,7 +3,13 @@
 /// Edit this file to define custom logic or remove it if it is not needed.
 /// Learn more about FRAME and the core library of Substrate FRAME pallets:
 /// https://substrate.dev/docs/en/knowledgebase/runtime/frame
-use frame_support::{debug, decl_error, decl_event, decl_module, decl_storage, traits::Get};
+use frame_support::{
+    debug, decl_error, decl_event, decl_module, decl_storage,
+    ensure,
+    traits::{Get, EnsureOrigin}, 
+    weights::{Pays},
+    dispatch::DispatchResultWithPostInfo,
+};
 use frame_system::{
     self as system, ensure_signed,
     offchain::{AppCrypto, CreateSignedTransaction, SendSignedTransaction, Signer},
@@ -13,10 +19,7 @@ use sp_std::prelude::*;
 
 use codec::{Decode, Encode};
 use sp_runtime::traits::SaturatedConversion;
-use sp_runtime::{
-    offchain::{http, Duration},
-    DispatchResult,
-};
+use sp_runtime::offchain::{http, Duration};
 
 use substrate_fixed::types::U16F16;
 mod ringbuffer;
@@ -71,7 +74,9 @@ pub trait Config: system::Config + CreateSignedTransaction<Call<Self>> {
     // Add other types and constants required to configure this pallet.
     type AuthorityId: AppCrypto<Self::Public, Self::Signature>;
     type Call: From<Call<Self>>;
-}
+    /// Origin for restricted extrinsics
+    /// Can be the root or another origin configured in the runtime
+    type RestrictedOrigin: EnsureOrigin<Self::Origin>;}
 
 decl_storage! {
     trait Store for Module<T: Config> as TFTPriceModule {
@@ -81,6 +86,15 @@ decl_storage! {
         pub AverageTftPrice: U16F16;
         pub TftPriceHistory get(fn get_value): map hasher(twox_64_concat) BufferIndex => ValueStruct;
         BufferRange get(fn range): (BufferIndex, BufferIndex) = (0, 0);
+        pub AllowedOrigin get(fn allowed_origin): T::AccountId;
+    }
+
+    add_extra_genesis {
+        config(allowed_origin): T::AccountId;
+
+        build(|_config| {
+            AllowedOrigin::<T>::set(_config.allowed_origin.clone());
+        });
     }
 }
 
@@ -95,7 +109,8 @@ decl_error! {
     pub enum Error for Module<T: Config> {
         ErrFetchingPrice,
         OffchainSignedTxError,
-        NoLocalAcctForSigning
+        NoLocalAcctForSigning,
+        AccountUnauthorizedToSetPrice,
     }
 }
 
@@ -106,14 +121,21 @@ decl_module! {
         fn deposit_event() = default;
 
         #[weight = 100_000_000 + T::DbWeight::get().writes(3)]
-        pub fn set_prices(origin, price: U16F16, block_number: T::BlockNumber){
-            let _ = ensure_signed(origin)?;
-            Self::calculate_and_set_price(price, block_number)?;
+        pub fn set_prices(origin, price: U16F16, block_number: T::BlockNumber) -> DispatchResultWithPostInfo {
+            let address = ensure_signed(origin)?;
+            ensure!(AllowedOrigin::<T>::get() == address, Error::<T>::AccountUnauthorizedToSetPrice);
+            Self::calculate_and_set_price(price, block_number)
+        }
+
+        #[weight = 100_000_000 + T::DbWeight::get().writes(3)]
+        pub fn set_allowed_origin(origin, target: T::AccountId) {
+            T::RestrictedOrigin::ensure_origin(origin)?;
+            AllowedOrigin::<T>::set(target);
         }
 
         fn offchain_worker(block_number: T::BlockNumber) {
             match Self::offchain_signed_tx(block_number) {
-                Ok(_) => debug::info!("worker executed"),
+                Ok(_) => debug::info!("price set"),
                 Err(err) => debug::info!("err: {:?}", err)
             }
         }
@@ -129,7 +151,7 @@ struct PriceInfo {
 }
 
 impl<T: Config> Module<T> {
-    fn calculate_and_set_price(price: U16F16, block_number: T::BlockNumber) -> DispatchResult {
+    fn calculate_and_set_price(price: U16F16, block_number: T::BlockNumber) -> DispatchResultWithPostInfo {
         debug::info!("price {:?}", price);
 
         LastBlockSet::<T>::put(block_number);
@@ -144,7 +166,7 @@ impl<T: Config> Module<T> {
         debug::info!("average price {:?}", average);
         AverageTftPrice::put(average);
 
-        Ok(())
+        Ok(Pays::No.into())
     }
 
     /// Fetch current price and return the result in cents.

--- a/substrate-node/node/src/chain_spec.rs
+++ b/substrate-node/node/src/chain_spec.rs
@@ -2,6 +2,7 @@ use sp_core::{Pair, Public, sr25519, ed25519};
 use tfchain_runtime::{
 	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, CouncilConfig, CouncilMembershipConfig,
 	SudoConfig, SystemConfig, WASM_BINARY, Signature, TfgridModuleConfig, TFTBridgeModuleConfig, ValidatorSetConfig, SessionConfig,
+	TFTPriceModuleConfig
 };
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_finality_grandpa::AuthorityId as GrandpaId;
@@ -117,6 +118,8 @@ pub fn development_config() -> Result<ChainSpec, String> {
 			],
 			// Bridge fee account
 			get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+			// TFT price pallet allow account
+			get_account_id_from_seed::<sr25519::Public>("Alice"),
 		),
 		// Bootnodes
 		vec![],
@@ -195,6 +198,8 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 			],
 			// Bridge fee account
 			get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+			// TFT price pallet allow account
+			get_account_id_from_seed::<sr25519::Public>("Alice"),
 		),
 		// Bootnodes
 		vec![],
@@ -220,6 +225,7 @@ fn testnet_genesis(
 	_enable_println: bool,
 	bridge_validator_accounts: Vec<AccountId>,
 	bridge_fee_account: AccountId,
+	tft_price_allowed_account: AccountId
 ) -> GenesisConfig {
 	GenesisConfig {
 		frame_system: Some(SystemConfig {
@@ -285,6 +291,10 @@ fn testnet_genesis(
 				get_account_id_from_seed::<sr25519::Public>("Eve"),
 			],
 			phantom: Default::default(),
-		}), 
+		}),
+		// just some default for development
+		pallet_tft_price: Some(TFTPriceModuleConfig {
+			allowed_origin: tft_price_allowed_account
+		})
 	}
 }

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -350,6 +350,7 @@ impl pallet_tft_price::Config for Runtime {
 	type AuthorityId = pallet_tft_price::crypto::AuthId;
 	type Call = Call;
 	type Event = Event;
+	type RestrictedOrigin = EnsureRootOrCouncilApproval;
 }
 
 impl pallet_validator::Config for Runtime {
@@ -567,7 +568,7 @@ construct_runtime!(
 		TfgridModule: pallet_tfgrid::{Module, Call, Config<T>, Storage, Event<T>},
 		SmartContractModule: pallet_smart_contract::{Module, Call, Storage, Event<T>},
 		TFTBridgeModule: pallet_tft_bridge::{Module, Call, Config<T>, Storage, Event<T>},
-		TFTPriceModule: pallet_tft_price::{Module, Call, Storage, Event<T>},
+		TFTPriceModule: pallet_tft_price::{Module, Call, Storage, Config<T>, Event<T>},
 		Scheduler: pallet_scheduler::{Module, Call, Storage, Event<T>},
 		BurningModule: pallet_burning::{Module, Call, Storage, Event<T>},
 		TFKVStore: pallet_kvstore::{Module, Call, Storage, Event<T>},


### PR DESCRIPTION
Changes:

- Price set call is now only callable by the `AllowedOrigin`. This origin can be changed with the council or root. #246 
- Price set call is now free of charge #245 