### PR TITLE
feat: add a lock to a part of the user funds when creating rent contract

### DIFF
--- a/pallets/pallet-smart-contract/src/lib.rs
+++ b/pallets/pallet-smart-contract/src/lib.rs
@@ -648,7 +648,7 @@ impl<T: Config> Module<T> {
         }
         let twin = pallet_tfgrid::Twins::<T>::get(contract.twin_id);
 
-        let balance: BalanceOf<T> = <T as Config>::Currency::free_balance(&twin.account_id);
+        let mut balance: BalanceOf<T> = <T as Config>::Currency::free_balance(&twin.account_id);
 
         let (mut amount_due, discount_received) =
             Self::calculate_contract_cost_tft(contract, balance)?;
@@ -663,7 +663,12 @@ impl<T: Config> Module<T> {
             contract.state,
             types::ContractState::Deleted(types::Cause::CanceledByUser)
         ) {
+            println!("unreserving currency");
             <T as Config>::Currency::unreserve(&twin.account_id, amount_due);
+            balance = <T as Config>::Currency::free_balance(&twin.account_id);
+            println!("balance now: {:?}", balance);
+            println!("amount due: {:?}", amount_due);
+
         }
 
         // if the total amount due exceeds the twin's balance, decomission contract

--- a/pallets/pallet-smart-contract/src/lib.rs
+++ b/pallets/pallet-smart-contract/src/lib.rs
@@ -662,12 +662,8 @@ impl<T: Config> Module<T> {
             contract.state,
             types::ContractState::Deleted(types::Cause::CanceledByUser)
         ) {
-            println!("unreserving currency");
             <T as Config>::Currency::unreserve(&twin.account_id, amount_due);
             balance = <T as Config>::Currency::free_balance(&twin.account_id);
-            println!("balance now: {:?}", balance);
-            println!("amount due: {:?}", amount_due);
-
         }
 
         // if the total amount due exceeds the twin's balance, decomission contract

--- a/pallets/pallet-smart-contract/src/lib.rs
+++ b/pallets/pallet-smart-contract/src/lib.rs
@@ -93,7 +93,6 @@ decl_error! {
         MethodIsDeprecated,
         NodeHasActiveContracts,
         NodeHasRentContract,
-        NotEnoughBalance,
     }
 }
 

--- a/pallets/pallet-smart-contract/src/lib.rs
+++ b/pallets/pallet-smart-contract/src/lib.rs
@@ -673,11 +673,13 @@ impl<T: Config> Module<T> {
             balance = <T as Config>::Currency::free_balance(&twin.account_id);
 
             // if the free balance + reserved balance is still not enough to cover the costs
-            // take whatever is left on the account and decomission the workload
+            // take whatever is left on the account
             if amount_due >= balance {
                 amount_due = balance;
-                decomission = true;
             }
+
+            // decomission the workload
+            decomission = true;
         }
 
         // Fetch the default pricing policy

--- a/pallets/pallet-smart-contract/src/tests.rs
+++ b/pallets/pallet-smart-contract/src/tests.rs
@@ -559,6 +559,16 @@ fn test_create_rent_contract() {
             contract.contract_type,
             types::ContractData::RentContract(rent_contract)
         );
+
+        let twin = TfgridModule::twins(2);
+        let reserved_balance = Balances::reserved_balance(&twin.account_id);
+        assert_ne!(reserved_balance, 0);
+
+        let (amount_due_as_u128, _) = calculate_tft_cost(10, 1, 2);
+        assert_ne!(amount_due_as_u128, 0);
+
+        // check if the reserved balance is equal to the amount due for 1 cycle
+        assert_eq!(reserved_balance as u128, amount_due_as_u128);
     });
 }
 

--- a/pallets/pallet-smart-contract/src/tests.rs
+++ b/pallets/pallet-smart-contract/src/tests.rs
@@ -544,6 +544,8 @@ fn test_multiple_contracts_billing_loop() {
 fn test_create_rent_contract() {
     new_test_ext().execute_with(|| {
         prepare_farm_and_node();
+        run_to_block(1);
+        TFTPriceModule::set_prices(Origin::signed(bob()), U16F16::from_num(0.05), 101).unwrap();
 
         let node_id = 1;
         assert_ok!(SmartContractModule::create_rent_contract(
@@ -564,6 +566,8 @@ fn test_create_rent_contract() {
 fn test_create_rent_contract_cancel_works() {
     new_test_ext().execute_with(|| {
         prepare_farm_and_node();
+        run_to_block(1);
+        TFTPriceModule::set_prices(Origin::signed(bob()), U16F16::from_num(0.05), 101).unwrap();
 
         let node_id = 1;
         assert_ok!(SmartContractModule::create_rent_contract(
@@ -595,6 +599,8 @@ fn test_create_rent_contract_cancel_works() {
 fn test_create_node_contract_other_owner_when_rent_contract_active_fails() {
     new_test_ext().execute_with(|| {
         prepare_farm_and_node();
+        run_to_block(1);
+        TFTPriceModule::set_prices(Origin::signed(bob()), U16F16::from_num(0.05), 101).unwrap();
 
         let node_id = 1;
         assert_ok!(SmartContractModule::create_rent_contract(
@@ -627,6 +633,7 @@ fn test_create_node_contract_same_owner_when_rent_contract_active_works() {
     new_test_ext().execute_with(|| {
         prepare_farm_and_node();
         run_to_block(1);
+        TFTPriceModule::set_prices(Origin::signed(bob()), U16F16::from_num(0.05), 101).unwrap();
 
         let node_id = 1;
         assert_ok!(SmartContractModule::create_rent_contract(


### PR DESCRIPTION
This PR makes sure to `reserve` an amount of TFT when creating a RentContract. This makes sure that no exploit can happen by deploying a RentContract without costs on all of the nodes.

The reserved amount remains in reserved state until the user actually cancels the contract. If the contract is canceled, the reserved currency is freed and this amount is used as the last amount due by the user (last billing cycle) 