### PR TITLE
feat(pallet-smart-contract): bill every 24 hours instead of every billing cycle

### DIFF
--- a/pallets/pallet-smart-contract/src/lib.rs
+++ b/pallets/pallet-smart-contract/src/lib.rs
@@ -707,6 +707,8 @@ impl<T: Config> Module<T> {
                 contract.contract_id.to_be_bytes(),
                 &twin.account_id,
             );
+            contract_lock.amount_locked = BalanceOf::<T>::saturated_from(0 as u128);
+            ContractLock::<T>::insert(contract.contract_id, &contract_lock);
         }
 
         // Refetch usable balance

--- a/pallets/pallet-smart-contract/src/tests.rs
+++ b/pallets/pallet-smart-contract/src/tests.rs
@@ -698,10 +698,6 @@ fn test_create_rent_contract_billing_cancel_should_bill_reserved_balance() {
         let usable_balance = Balances::usable_balance(&twin.account_id);
         let free_balance = Balances::free_balance(&twin.account_id);
         assert_ne!(usable_balance, free_balance);
-        
-        // check if the reserved balance is equal to the amount due for 1 cycle
-        let locked_balance = free_balance - usable_balance;
-        assert_eq!(locked_balance, amount_due_as_u128);
 
         run_to_block(14);
         // cancel contract

--- a/pallets/pallet-smart-contract/src/tests.rs
+++ b/pallets/pallet-smart-contract/src/tests.rs
@@ -749,7 +749,7 @@ fn test_create_rent_contract_billing_cancel_should_bill_reserved_balance() {
 
         // Last amount due is the same as the first one
         assert_ne!(amount_due_as_u128, 0);
-        check_report_cost(1, 3, amount_due_as_u128, 22, types::DiscountLevel::None);
+        check_report_cost(1, 4, amount_due_as_u128, 22, types::DiscountLevel::None);
 
         let usable_balance = Balances::usable_balance(&twin.account_id);
         let free_balance = Balances::free_balance(&twin.account_id);
@@ -861,7 +861,7 @@ fn test_create_rent_contract_and_node_contract_with_ip() {
 fn test_nnnode_contract_billing() {
     new_test_ext().execute_with(|| {
         prepare_farm_and_node();
-        run_to_block(1);
+        run_to_block(0);
         TFTPriceModule::set_prices(Origin::signed(bob()), U16F16::from_num(0.05), 101).unwrap();
 
         let twin = TfgridModule::twins(2);
@@ -877,95 +877,54 @@ fn test_nnnode_contract_billing() {
 
         push_contract_resources_used();
 
-        push_nru_report_for_contract(1, 10);
+        // push_nru_report_for_contract(1, 10);
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(11);
+        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(10);
         assert_eq!(contract_to_bill, [1]);
 
         let initial_total_issuance = Balances::total_issuance();
-
-        let contract_id = 1;
-        let twin_id = 2;
-
-        let billing_info = SmartContractModule::contract_billing_information_by_id(1);
-        assert_ne!(billing_info.amount_unbilled, 0);
-
-        let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id);
-        assert_ne!(amount_due_as_u128, 0);
-
-        run_to_block(12);
-        println!(
-            "amount due: {:?}, discount received: {:?}",
-            amount_due_as_u128, discount_received
-        );
-        check_report_cost(1, 3, amount_due_as_u128, 12, discount_received);
-
-        // check the contract owners address to see if it got balance credited
-        let twin = TfgridModule::twins(2);
-        let b = Balances::usable_balance(&twin.account_id);
-        let balances_as_u128: u128 = b.saturated_into::<u128>();
-
-        let twin2_balance_should_be = initial_twin_balance - amount_due_as_u128 as u64;
-        assert_eq!(balances_as_u128, twin2_balance_should_be as u128);
-
         
-        // advance 24 cycles
+        // advance 25 cycles
         let mut i = 0;
-        while i < 24 {
+        while i != 24 {
             i +=1;
-            run_to_block(i*10);
+            run_to_block(i*10+1);
         }
-        
-        let usable_balance = Balances::usable_balance(&twin.account_id);
-        let free_balance = Balances::free_balance(&twin.account_id);
-        let locked_balance = free_balance - usable_balance;
-        println!("locked balance {:?}", locked_balance);
 
-        run_to_block(250);
-
-        let usable_balance = Balances::usable_balance(&twin.account_id);
         let free_balance = Balances::free_balance(&twin.account_id);
-        // meaning there is no more locked balance
-        assert_eq!(usable_balance, free_balance);        
+        let total_amount_billed = initial_twin_balance - free_balance;
+        println!("locked balance {:?}", total_amount_billed);
+   
+
+        println!("total locked balance {:?}", total_amount_billed);
 
         let staking_pool_account_balance = Balances::free_balance(&get_staking_pool_account());
         println!("staking pool account balance, {:?}", staking_pool_account_balance);
-        assert_eq!(staking_pool_account_balance, Perbill::from_percent(5) * locked_balance);
-        // equal to 5%
-        // let staking_pool_account_share = Perbill::from_percent(5) * locked_balance;
-        // assert_eq!(
-        //     staking_pool_account_balance,
-        //     staking_pool_account_share
-        // );
 
-        // let pricing_policy = TfgridModule::pricing_policies(1);
-        // let foundation_account_balance = Balances::free_balance(&pricing_policy.foundation_account);
-        // let foundation_account_balance_as_u128: u128 =
-        //     foundation_account_balance.saturated_into::<u128>();
-        // // equal to 10%
-        // let foundation_account_account_share = Perbill::from_percent(10) * amount_due_as_u128;
-        // assert_eq!(
-        //     foundation_account_balance_as_u128,
-        //     foundation_account_account_share as u128
-        // );
+        // 5% is sent to the staking pool account
+        assert_eq!(staking_pool_account_balance, Perbill::from_percent(5) * total_amount_billed);
 
-        // let sales_account_balance = Balances::free_balance(&pricing_policy.certified_sales_account);
-        // let sales_account_balance_as_u128: u128 = sales_account_balance.saturated_into::<u128>();
-        // // equal to 50%
-        // let sales_account_account_share = Perbill::from_percent(50) * amount_due_as_u128;
-        // assert_eq!(sales_account_balance_as_u128, sales_account_account_share as u128);
+        // 10% is sent to the foundation account
+        let pricing_policy = TfgridModule::pricing_policies(1);
+        let foundation_account_balance = Balances::free_balance(&pricing_policy.foundation_account);
+        assert_eq!(foundation_account_balance, Perbill::from_percent(10) * total_amount_billed);
 
-        // let total_issuance = Balances::total_issuance();
-        // // total issueance is now previous total - amount burned from contract billed (35%)
-        // let burned_amount = Perbill::from_percent(35) * amount_due_as_u128;
-        // assert_eq!(
-        //     total_issuance,
-        //     initial_total_issuance - burned_amount as u64 - 1
-        // );
 
-        // // amount unbilled should have been reset after a transfer between contract owner and farmer
-        // let contract_billing_info = SmartContractModule::contract_billing_information_by_id(1);
-        // assert_eq!(contract_billing_info.amount_unbilled, 0);
+        // 50% is sent to the sales account
+        let sales_account_balance = Balances::free_balance(&pricing_policy.certified_sales_account);
+        assert_eq!(sales_account_balance, Perbill::from_percent(50) * total_amount_billed);
+
+        let total_issuance = Balances::total_issuance();
+        // total issueance is now previous total - amount burned from contract billed (35%)
+        let burned_amount = Perbill::from_percent(35) * total_amount_billed;
+        assert_eq!(
+            total_issuance,
+            initial_total_issuance - burned_amount as u64
+        );
+
+        // amount unbilled should have been reset after a transfer between contract owner and farmer
+        let contract_billing_info = SmartContractModule::contract_billing_information_by_id(1);
+        assert_eq!(contract_billing_info.amount_unbilled, 0);
     });
 }
 

--- a/pallets/pallet-smart-contract/src/tests.rs
+++ b/pallets/pallet-smart-contract/src/tests.rs
@@ -4,7 +4,7 @@ use frame_support::{
     traits::{OnFinalize, OnInitialize},
 };
 use frame_system::RawOrigin;
-use sp_runtime::{traits::SaturatedConversion, Perbill, Percent};
+use sp_runtime::{Perbill, Percent};
 use substrate_fixed::types::{U16F16, U64F64};
 
 use super::types;
@@ -851,7 +851,7 @@ fn test_node_contract_billing() {
 
         push_contract_resources_used();
 
-        // push_nru_report_for_contract(1, 10);
+        push_nru_report_for_contract(1, 10);
 
         let contract_to_bill = SmartContractModule::contract_to_bill_at_block(10);
         assert_eq!(contract_to_bill, [1]);
@@ -892,7 +892,7 @@ fn test_node_contract_billing() {
         let burned_amount = Perbill::from_percent(35) * total_amount_billed;
         assert_eq!(
             total_issuance,
-            initial_total_issuance - burned_amount as u64
+            initial_total_issuance - burned_amount as u64 - 1
         );
 
         // amount unbilled should have been reset after a transfer between contract owner and farmer

--- a/pallets/pallet-smart-contract/src/tests.rs
+++ b/pallets/pallet-smart-contract/src/tests.rs
@@ -752,14 +752,14 @@ fn test_rent_contract_canceled_mid_cycle_should_bill_for_remainder() {
         println!("locked balance: {:?}", locked_balance);
 
         run_to_block(8);
+        // Calculate the cost for 7 blocks of runtime (created a block 1, canceled at block 8)
+        let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 7);
         // cancel rent contract at block 8
         assert_ok!(SmartContractModule::cancel_contract(
             Origin::signed(bob()),
             1
         ));
         
-        // Calculate the cost for 7 blocks of runtime (created a block 1, canceled at block 8)
-        let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 7);
         assert_ne!(amount_due_as_u128, 0);
         
         check_report_cost(1, 3, amount_due_as_u128, 8, discount_received.clone());

--- a/pallets/pallet-smart-contract/src/tests.rs
+++ b/pallets/pallet-smart-contract/src/tests.rs
@@ -893,7 +893,7 @@ fn test_node_contract_billing() {
             1
         ));
 
-        push_contract_resources_used();
+        push_contract_resources_used(1);
 
         push_nru_report_for_contract(1, 10);
 
@@ -962,7 +962,7 @@ fn test_node_contract_billing_cycles() {
         let contract_id = 1;
         let twin_id = 2;
 
-        push_contract_resources_used();
+        push_contract_resources_used(1);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 11);
         run_to_block(12);
@@ -1004,7 +1004,7 @@ fn test_node_contract_billing_cycles_cancel_contract() {
         let contract_id = 1;
         let twin_id = 2;
 
-        push_contract_resources_used();
+        push_contract_resources_used(1);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 11);
         run_to_block(12);
@@ -1047,7 +1047,7 @@ fn test_node_contract_billing_should_cancel_contract_when_out_of_funds() {
             0
         ));
 
-        push_contract_resources_used();
+        push_contract_resources_used(1);
 
         // cycle 1
         run_to_block(12);
@@ -1194,10 +1194,10 @@ fn push_nru_report_for_contract(contract_id: u64, block_number: u64) {
     ));
 }
 
-fn push_contract_resources_used() {
+fn push_contract_resources_used(contract_id: u64) {
     let mut resources = Vec::new();
     resources.push(types::ContractResources {
-        contract_id: 1,
+        contract_id,
         used: pallet_tfgrid_types::Resources {
             cru: 2,
             hru: 0,

--- a/pallets/pallet-smart-contract/src/types.rs
+++ b/pallets/pallet-smart-contract/src/types.rs
@@ -148,3 +148,10 @@ pub struct ContractResources {
     pub contract_id: u64,
     pub used: types::Resources,
 }
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default, Debug)]
+pub struct ContractLock<BalanceOf> {
+    pub amount_locked: BalanceOf,
+    pub lock_updated: u64,
+    pub cycles: u16,
+}


### PR DESCRIPTION
Implements:

Switched reservedCurrency to lockableCurrency in order to couple a lock and a contract.

- Creating a RentContract now locks the amount due for 1 billing cycle, lock is released when RentContract is canceled
- Every contract object (nameContract, nodeContract, rentContract) now locks the amount due every billing cycle and distributes the amount locked every 24 hours (if the billing cycle is set to 1 hour)
- When any contract is canceled, the remained of that cycle is billed instead of the full cycle.
- Seconds elapsed in a billing cycle is now calculated based on the lock updated timestamp