### PR TITLE
feat: grace period for contracts

### DIFF
--- a/substrate-node/pallets/pallet-smart-contract/spec.md
+++ b/substrate-node/pallets/pallet-smart-contract/spec.md
@@ -64,6 +64,16 @@ Billing will be done in Database Tokens and will be send to the corresponding fa
 
 The main currency of this chain. More information on this is explained here: TODO
 
+## Grace period for contracts
+
+Implements a grace period state `GracePeriod(startBlockNumber)` for all contract types
+A grace period is a static amount of time defined by the runtime configuration.
+
+
+Grace period is triggered if the amount due for a billing cycle is larger than the user's balance. 
+A grace period is removed on a contract if the next billing cycles notices that the user reloaded the balance on his account. 
+If this happens, the contract is set back to created state. If a user ignores a graced-out contract, the contract is deleted after the time defined by Grace Period configuration trait.
+
 ## Footnote
 
 Sending the workloads encrypted to the chain makes sure that nobody except the destination Node can read the deployment's information as this can contain sensitive data. This way we also don't need to convert all the Zero OS primitive types to a Rust implementation and we can keep it relatively simple.

--- a/substrate-node/pallets/pallet-smart-contract/src/lib.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/lib.rs
@@ -752,7 +752,7 @@ impl<T: Config> Module<T> {
 
     fn handle_grace(contract: &mut types::Contract, usable_balance: BalanceOf<T>, amount_due: BalanceOf<T>) -> Result<&mut types::Contract, DispatchError> {
         let current_block = <frame_system::Module<T>>::block_number().saturated_into::<u64>();
-        let node_id = Self::get_node_id(contract);
+        let node_id = contract.get_node_id();
 
         match contract.state {
             types::ContractState::GracePeriod(grace_start) => {
@@ -1271,16 +1271,6 @@ impl<T: Config> Module<T> {
         match contract.contract_type.clone() {
             types::ContractData::RentContract(c) => Ok(c),
             _ => return Err(DispatchError::from(Error::<T>::InvalidContractType)),
-        }
-    }
-
-    pub fn get_node_id(
-        contract: &types::Contract
-    ) -> u32 {
-        match contract.contract_type.clone() {
-            types::ContractData::RentContract(c) => c.node_id,
-            types::ContractData::NodeContract(c) => c.node_id,
-            types::ContractData::NameContract(_) => 0,
         }
     }
 

--- a/substrate-node/pallets/pallet-smart-contract/src/lib.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/lib.rs
@@ -69,8 +69,8 @@ decl_event!(
         UpdatedUsedResources(types::ContractResources),
         NruConsumptionReportReceived(types::NruConsumption),
         RentContractCanceled(u64),
-        ContractGracePeriodStarted(u64, u64),
-        ContractGracePeriodEnded(u64),
+        ContractGracePeriodStarted(u32, u64, u64),
+        ContractGracePeriodEnded(u32, u64),
     }
 );
 
@@ -679,13 +679,14 @@ impl<T: Config> Module<T> {
         
         let mut decomission = false;
         let current_block = <frame_system::Module<T>>::block_number().saturated_into::<u64>();
+        let node_id = Self::get_node_id(contract);
 
         match contract.state {
             types::ContractState::GracePeriod(grace_start) => {
                 // if the usable balance is recharged, we can move the contract to created state again
                 if usable_balance > amount_due {
                     Self::_update_contract_state(contract, &types::ContractState::Created)?;
-                    Self::deposit_event(RawEvent::ContractGracePeriodEnded(contract.contract_id))
+                    Self::deposit_event(RawEvent::ContractGracePeriodEnded(node_id, contract.contract_id))
                 } else {
                     let diff = current_block - grace_start;
                     // If the contract grace period ran out, we can decomission the contract
@@ -702,7 +703,7 @@ impl<T: Config> Module<T> {
                 if amount_due >= usable_balance {
                     Self::_update_contract_state(contract, &types::ContractState::GracePeriod(current_block))?;
                     // We can't lock the amount due on the contract's lock because the user ran out of funds
-                    Self::deposit_event(RawEvent::ContractGracePeriodStarted(contract.contract_id, current_block.saturated_into()));
+                    Self::deposit_event(RawEvent::ContractGracePeriodStarted(node_id, contract.contract_id, current_block.saturated_into()));
                 }
             }
         }
@@ -1261,6 +1262,16 @@ impl<T: Config> Module<T> {
         match contract.contract_type.clone() {
             types::ContractData::RentContract(c) => Ok(c),
             _ => return Err(DispatchError::from(Error::<T>::InvalidContractType)),
+        }
+    }
+
+    pub fn get_node_id(
+        contract: &types::Contract
+    ) -> u32 {
+        match contract.contract_type.clone() {
+            types::ContractData::RentContract(c) => c.node_id,
+            types::ContractData::NodeContract(c) => c.node_id,
+            types::ContractData::NameContract(_) => 0,
         }
     }
 

--- a/substrate-node/pallets/pallet-smart-contract/src/lib.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/lib.rs
@@ -69,8 +69,8 @@ decl_event!(
         UpdatedUsedResources(types::ContractResources),
         NruConsumptionReportReceived(types::NruConsumption),
         RentContractCanceled(u64),
-        ContractGracePeriodStarted(u32, u64, u64),
-        ContractGracePeriodEnded(u32, u64),
+        ContractGracePeriodStarted(u64, u32, u32, u64),
+        ContractGracePeriodEnded(u64, u32, u32),
     }
 );
 
@@ -686,7 +686,7 @@ impl<T: Config> Module<T> {
                 // if the usable balance is recharged, we can move the contract to created state again
                 if usable_balance > amount_due {
                     Self::_update_contract_state(contract, &types::ContractState::Created)?;
-                    Self::deposit_event(RawEvent::ContractGracePeriodEnded(node_id, contract.contract_id))
+                    Self::deposit_event(RawEvent::ContractGracePeriodEnded(contract.contract_id, node_id, contract.twin_id))
                 } else {
                     let diff = current_block - grace_start;
                     // If the contract grace period ran out, we can decomission the contract
@@ -703,7 +703,7 @@ impl<T: Config> Module<T> {
                 if amount_due >= usable_balance {
                     Self::_update_contract_state(contract, &types::ContractState::GracePeriod(current_block))?;
                     // We can't lock the amount due on the contract's lock because the user ran out of funds
-                    Self::deposit_event(RawEvent::ContractGracePeriodStarted(node_id, contract.contract_id, current_block.saturated_into()));
+                    Self::deposit_event(RawEvent::ContractGracePeriodStarted(contract.contract_id, node_id, contract.twin_id, current_block.saturated_into()));
                 }
             }
         }

--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -116,6 +116,7 @@ impl Config for TestRuntime {
     type StakingPoolAccount = StakingPoolAccount;
     type BillingFrequency = BillingFrequency;
     type DistributionFrequency = DistributionFrequency;
+    type GracePeriod = GracePeriod;
     type WeightInfo = weights::SubstrateWeight<TestRuntime>; 
 }
 

--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -105,6 +105,8 @@ impl pallet_timestamp::Config for TestRuntime {
 
 parameter_types! {
     pub const BillingFrequency: u64 = 10;
+    pub const GracePeriod: u64 = 100;
+    pub const DistributionFrequency: u16 = 24;
 }
 
 use weights;
@@ -113,6 +115,7 @@ impl Config for TestRuntime {
     type Currency = Balances;
     type StakingPoolAccount = StakingPoolAccount;
     type BillingFrequency = BillingFrequency;
+    type DistributionFrequency = DistributionFrequency;
     type WeightInfo = weights::SubstrateWeight<TestRuntime>; 
 }
 

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -928,7 +928,7 @@ fn test_node_contract_out_of_funds_should_move_state_to_graceperiod_works() {
 
         let mut expected_events: std::vec::Vec<RawEvent<AccountId, BalanceOf<TestRuntime>>> =
             Vec::new();
-        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 1, 21));
+        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 1, 3, 21));
 
         assert_eq!(our_events[3], expected_events[0]);
 
@@ -997,7 +997,7 @@ fn test_node_contract_grace_period_cancels_contract_when_grace_period_ends_works
 
         let mut expected_events: std::vec::Vec<RawEvent<AccountId, BalanceOf<TestRuntime>>> =
             Vec::new();
-        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 1, 21));
+        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 1, 3, 21));
 
         assert_eq!(our_events[3], expected_events[0]);
 

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -1313,6 +1313,17 @@ fn test_rent_contract_canceled_due_to_out_of_funds_should_cancel_node_contracts_
         push_contract_resources_used(2);
 
         run_to_block(12);
+        run_to_block(22);
+        run_to_block(32);
+        run_to_block(42);
+        run_to_block(52);
+        run_to_block(62);
+        run_to_block(72);
+        run_to_block(82);
+        run_to_block(92);
+        run_to_block(102);
+        run_to_block(112);
+        run_to_block(122);
 
         // let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 11);
         // assert_ne!(amount_due_as_u128, 0);
@@ -1336,18 +1347,18 @@ fn test_rent_contract_canceled_due_to_out_of_funds_should_cancel_node_contracts_
         // Event 1: Rent contract created
         // Event 2: Node Contract created
         // Event 3: Updated used resources
-        // Event 4: Tokens burned
-        // Event 5: Rent contract billed
-        // Event 6: Node contract canceled
-        // Event 7: Rent contract Canceled
+        // Event 4: Grace period started
+        // Event 5-15: Rent contract billed
+        // Event 16: Node contract canceled
+        // Event 17: Rent contract Canceled
         // => no Node Contract billed event
-        assert_eq!(our_events.len(), 7);
+        assert_eq!(our_events.len(), 17);
 
         let expected_events: std::vec::Vec<RawEvent<AccountId, BalanceOf<TestRuntime>>> =
             vec![RawEvent::NodeContractCanceled(2, 1, 3), RawEvent::RentContractCanceled(1)];
         
-        assert_eq!(our_events[5], expected_events[0]);
-        assert_eq!(our_events[6], expected_events[1]);
+        assert_eq!(our_events[15], expected_events[0]);
+        assert_eq!(our_events[16], expected_events[1]);
     });
 }
 

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -931,6 +931,53 @@ fn test_node_contract_out_of_funds_should_move_state_to_graceperiod_works() {
         expected_events.push(RawEvent::ContractGracePeriodStarted(1, 1, 3, 21));
 
         assert_eq!(our_events[3], expected_events[0]);
+    });
+}
+
+#[test]
+fn test_restore_node_contract_in_grace_works() {
+    new_test_ext().execute_with(|| {
+        prepare_farm_and_node();
+        run_to_block(1);
+        TFTPriceModule::set_prices(Origin::signed(bob()), U16F16::from_num(0.05), 101).unwrap();
+
+        assert_ok!(SmartContractModule::create_node_contract(
+            Origin::signed(charlie()),
+            1,
+            "some_data".as_bytes().to_vec(),
+            "hash".as_bytes().to_vec(),
+            0
+        ));
+
+        push_contract_resources_used(1);
+
+        // cycle 1
+        run_to_block(12);
+
+        // cycle 2
+        // user does not have enough funds to pay for 2 cycles
+        run_to_block(22);
+
+        let c1 = SmartContractModule::contracts(1);
+        assert_eq!(c1.state, types::ContractState::GracePeriod(21));
+
+        let our_events = System::events()
+            .into_iter()
+            .map(|r| r.event)
+            .filter_map(|e| {
+                if let Event::pallet_smart_contract(inner) = e {
+                    Some(inner)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut expected_events: std::vec::Vec<RawEvent<AccountId, BalanceOf<TestRuntime>>> =
+            Vec::new();
+        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 1, 3, 21));
+
+        assert_eq!(our_events[3], expected_events[0]);
 
         let contract_to_bill = SmartContractModule::contract_to_bill_at_block(31);
         assert_eq!(contract_to_bill.len(), 1);
@@ -940,6 +987,7 @@ fn test_node_contract_out_of_funds_should_move_state_to_graceperiod_works() {
         assert_eq!(contract_to_bill.len(), 1);
         run_to_block(42);
 
+        // Transfer some balance to the owner of the contract to trigger the grace period to stop
         Balances::transfer(Origin::signed(bob()), charlie(), 100000000).unwrap();
 
         let contract_to_bill = SmartContractModule::contract_to_bill_at_block(51);
@@ -954,7 +1002,6 @@ fn test_node_contract_out_of_funds_should_move_state_to_graceperiod_works() {
         assert_eq!(c1.state, types::ContractState::Created);
     });
 }
-
 
 #[test]
 fn test_node_contract_grace_period_cancels_contract_when_grace_period_ends_works() {
@@ -1292,6 +1339,163 @@ fn test_create_rent_contract_and_node_contract_with_ip_billing_works() {
         // Event 3: Rent contract billed
         // Event 6: Node Contract billed
         assert_eq!(our_events.len(), 4);
+    });
+}
+
+#[test]
+fn test_rent_contract_out_of_funds_should_move_state_to_graceperiod_works() {
+    new_test_ext().execute_with(|| {
+        prepare_dedicated_farm_and_node();
+        run_to_block(1);
+        TFTPriceModule::set_prices(Origin::signed(bob()), U16F16::from_num(0.05), 101).unwrap();
+
+        let node_id = 1;
+        assert_ok!(SmartContractModule::create_rent_contract(
+            Origin::signed(charlie()),
+            node_id
+        ));
+
+        // cycle 1
+        // user does not have enough funds to pay for 1 cycle
+        run_to_block(12);
+
+        let c1 = SmartContractModule::contracts(1);
+        assert_eq!(c1.state, types::ContractState::GracePeriod(11));
+
+        let our_events = System::events()
+            .into_iter()
+            .map(|r| r.event)
+            .filter_map(|e| {
+                if let Event::pallet_smart_contract(inner) = e {
+                    Some(inner)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut expected_events: std::vec::Vec<RawEvent<AccountId, BalanceOf<TestRuntime>>> =
+            Vec::new();
+        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 1, 3, 11));
+
+        assert_eq!(our_events[1], expected_events[0]);
+    });
+}
+
+
+#[test]
+fn test_restore_rent_contract_in_grace_works() {
+    new_test_ext().execute_with(|| {
+        prepare_dedicated_farm_and_node();
+        run_to_block(1);
+        TFTPriceModule::set_prices(Origin::signed(bob()), U16F16::from_num(0.05), 101).unwrap();
+
+        let node_id = 1;
+        assert_ok!(SmartContractModule::create_rent_contract(
+            Origin::signed(charlie()),
+            node_id
+        ));
+
+        // cycle 1
+        run_to_block(12);
+
+        let c1 = SmartContractModule::contracts(1);
+        assert_eq!(c1.state, types::ContractState::GracePeriod(11));
+
+        let our_events = System::events()
+            .into_iter()
+            .map(|r| r.event)
+            .filter_map(|e| {
+                if let Event::pallet_smart_contract(inner) = e {
+                    Some(inner)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut expected_events: std::vec::Vec<RawEvent<AccountId, BalanceOf<TestRuntime>>> =
+            Vec::new();
+        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 1, 3, 11));
+
+        assert_eq!(our_events[1], expected_events[0]);
+
+        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(21);
+        assert_eq!(contract_to_bill.len(), 1);
+        run_to_block(22);
+
+        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(31);
+        assert_eq!(contract_to_bill.len(), 1);
+        run_to_block(32);
+
+        // Transfer some balance to the owner of the contract to trigger the grace period to stop
+        Balances::transfer(Origin::signed(bob()), charlie(), 100000000).unwrap();
+
+        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(41);
+        assert_eq!(contract_to_bill.len(), 1);
+        run_to_block(42);
+
+        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(51);
+        assert_eq!(contract_to_bill.len(), 1);
+        run_to_block(52);
+
+        let c1 = SmartContractModule::contracts(1);
+        assert_eq!(c1.state, types::ContractState::Created);
+    });
+}
+
+#[test]
+fn test_rent_contract_grace_period_cancels_contract_when_grace_period_ends_works() {
+    new_test_ext().execute_with(|| {
+        prepare_dedicated_farm_and_node();
+        run_to_block(1);
+        TFTPriceModule::set_prices(Origin::signed(bob()), U16F16::from_num(0.05), 101).unwrap();
+
+        let node_id = 1;
+        assert_ok!(SmartContractModule::create_rent_contract(
+            Origin::signed(charlie()),
+            node_id
+        ));
+
+        // cycle 1
+        run_to_block(12);
+
+        let c1 = SmartContractModule::contracts(1);
+        assert_eq!(c1.state, types::ContractState::GracePeriod(11));
+
+        let our_events = System::events()
+            .into_iter()
+            .map(|r| r.event)
+            .filter_map(|e| {
+                if let Event::pallet_smart_contract(inner) = e {
+                    Some(inner)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut expected_events: std::vec::Vec<RawEvent<AccountId, BalanceOf<TestRuntime>>> =
+            Vec::new();
+        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 1, 3, 11));
+
+        assert_eq!(our_events[1], expected_events[0]);
+
+        run_to_block(22);
+        run_to_block(32);
+        run_to_block(42);
+        run_to_block(52);
+        run_to_block(62);
+        run_to_block(72);
+        run_to_block(82);
+        run_to_block(92);
+        run_to_block(102);
+        run_to_block(112);
+        run_to_block(122);
+        run_to_block(132);
+
+        let c1 = SmartContractModule::contracts(1);
+        assert_eq!(c1, types::Contract::default());
     });
 }
 

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -928,7 +928,7 @@ fn test_node_contract_out_of_funds_should_move_state_to_graceperiod_works() {
 
         let mut expected_events: std::vec::Vec<RawEvent<AccountId, BalanceOf<TestRuntime>>> =
             Vec::new();
-        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 21));
+        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 1, 21));
 
         assert_eq!(our_events[3], expected_events[0]);
 
@@ -997,7 +997,7 @@ fn test_node_contract_grace_period_cancels_contract_when_grace_period_ends_works
 
         let mut expected_events: std::vec::Vec<RawEvent<AccountId, BalanceOf<TestRuntime>>> =
             Vec::new();
-        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 21));
+        expected_events.push(RawEvent::ContractGracePeriodStarted(1, 1, 21));
 
         assert_eq!(our_events[3], expected_events[0]);
 

--- a/substrate-node/pallets/pallet-smart-contract/src/types.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/types.rs
@@ -4,6 +4,8 @@ use substrate_fixed::types::U64F64;
 
 use pallet_tfgrid::types;
 
+pub type BlockNumber = u64;
+
 /// Utility type for managing upgrades/migrations.
 #[derive(Encode, Decode, Clone, Debug, PartialEq)]
 pub enum PalletStorageVersion {
@@ -75,6 +77,7 @@ pub struct ContractBillingInformation {
 pub enum ContractState {
     Created,
     Deleted(Cause),
+    GracePeriod(BlockNumber)
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]

--- a/substrate-node/pallets/pallet-smart-contract/src/types.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/types.rs
@@ -28,6 +28,14 @@ impl Contract {
     pub fn is_state_delete(&self) -> bool {
         matches!(self.state, ContractState::Deleted(_))
     }
+
+    pub fn get_node_id(&self) -> u32 {
+        match self.contract_type.clone() {
+            ContractData::RentContract(c) => c.node_id,
+            ContractData::NodeContract(c) => c.node_id,
+            ContractData::NameContract(_) => 0,
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default, Debug)]

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -312,6 +312,8 @@ impl pallet_tfgrid::Config for Runtime {
 parameter_types! {
     pub StakingPoolAccount: AccountId = get_staking_pool_account();
 	pub BillingFrequency: u64 = 600;
+	pub GracePeriod: u64 = (14 * DAYS).into();
+	pub DistributionFrequency: u16 = 24;
 }
 
 pub fn get_staking_pool_account() -> AccountId {
@@ -324,6 +326,8 @@ impl pallet_smart_contract::Config for Runtime {
 	type Currency = Balances;
 	type StakingPoolAccount = StakingPoolAccount;
 	type BillingFrequency = BillingFrequency;
+	type DistributionFrequency = DistributionFrequency;
+	type GracePeriod = GracePeriod;
 	type WeightInfo = pallet_smart_contract::weights::SubstrateWeight<Runtime>;
 }
 

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -312,7 +312,7 @@ impl pallet_tfgrid::Config for Runtime {
 parameter_types! {
     pub StakingPoolAccount: AccountId = get_staking_pool_account();
 	pub BillingFrequency: u64 = 600;
-	pub GracePeriod: u64 = (14 * DAYS).into();
+	pub GracePeriod: u64 = (6 * HOURS).into();
 	pub DistributionFrequency: u16 = 24;
 }
 


### PR DESCRIPTION
Implements a grace period state `GracePeriod(startBlockNumber)` for all contract types

A grace period is triggered if the amount due for a billing cycle is larger than the user's balance. A grace period is a static amount of time defined by the runtime configuration. A grace period is removed on a contract if the user reloads the balance on his account. If this happens, the contract is set back to `created` state. If a user ignores a graced out contract, the contract is deleted after the time defined by Grace Period configuration trait.