### PR TITLE
Update README to reflect current build instructions and prerequisites.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,26 +4,37 @@
 
 ### Node
 
-You will need a specific version of rust nightly in order to compile:
+Ensure you have the following installed first (they can be installed using apt-get install): 
+- librocksdb-dev
+- libclang-dev
+- clang lldb lld
+- build-essential 
 
-`rustup install nightly`
-
-Wasm toolchain:
-
-`rustup target add wasm32-unknown-unknown --toolchain nightly`
+You will also need  rust and nightly installed. 
+To install Rust:
+```
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+To install nightly:
+```
+rustup install nightly-2021-06-09
+```
 
 Now you can build.
 
-```sh
+```
 cd substrate-node
-# make sure you run nightly
-rustup override set nightly
-cargo build
+
+rustup target add wasm32-unknown-unknown --toolchain nightly-2021-06-09
+
+cargo +nightly-2021-06-09 build --release
 ```
 
-This will build the node binary in debug mode, once built you can execute it by doing following:
+This will build the node binary in release mode, once built you can execute it by doing following:
 
-`./target/debug/tfchain --dev --ws-external`
+```
+./target/release/tfchain --ws-external --rpc-methods Unsafe --dev
+```
 
 > You need the `ws-external` flag in order to connect from a zos node to substrate in a local setup.
 

--- a/readme.md
+++ b/readme.md
@@ -60,3 +60,10 @@ See [process](./substrate-node/upgrade_process.md)
 ### Client
 
 You can use the client to interact with the chain, [read more](./cli-tool/readme.md)
+
+### Data Cleanup:
+To wipe data run:
+
+```
+rm -rf /home/<username>/.local/share/tfchain/chains/
+```

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,8 @@
 
 ## Installation
 
-### Node
-
-Ensure you have the following installed first (they can be installed using apt-get install): 
+#### Prerequisites:
+Ensure you have the following installed first: 
 - librocksdb-dev
 - libclang-dev
 - clang lldb lld
@@ -19,14 +18,20 @@ To install nightly:
 ```
 rustup install nightly-2021-06-09
 ```
-
-Now you can build.
+### Node
+Navigate to substrate node:
 
 ```
 cd substrate-node
+```
 
+Add Wasm toolchain:
+```
 rustup target add wasm32-unknown-unknown --toolchain nightly-2021-06-09
+```
 
+Now you can build:
+```
 cargo +nightly-2021-06-09 build --release
 ```
 


### PR DESCRIPTION
The current README is outdated and missing necessary prerequisites to have a successful installation, build and run of 
 the substrate node. It is also missing a data cleanup section for when the substrate node is no longer needed.  Therefore, the prerequisites and data clean-up sections were added. The installation section was updated to include the updated CLI commands needed to successfully build and run the substrate node.  