### PR TITLE
fix: grace out node contracts if rent contract is graced out

### DIFF
--- a/substrate-node/pallets/pallet-smart-contract/src/lib.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/lib.rs
@@ -888,11 +888,7 @@ impl<T: Config> Pallet<T> {
                         twin_id: contract.twin_id,
                     });
                     // If the contract is a rent contract, also move state on associated node contracts
-                    Self::handle_grace_rent_contract(
-                        contract,
-                        types::ContractState::Created,
-                        current_block,
-                    )?;
+                    Self::handle_grace_rent_contract(contract, types::ContractState::Created)?;
                 } else {
                     let diff = current_block - grace_start;
                     // If the contract grace period ran out, we can decomission the contract
@@ -925,7 +921,6 @@ impl<T: Config> Pallet<T> {
                     Self::handle_grace_rent_contract(
                         contract,
                         types::ContractState::GracePeriod(current_block),
-                        current_block,
                     )?;
                 }
             }
@@ -937,7 +932,6 @@ impl<T: Config> Pallet<T> {
     fn handle_grace_rent_contract(
         contract: &mut types::Contract,
         state: types::ContractState,
-        block_number: u64,
     ) -> DispatchResultWithPostInfo {
         match &contract.contract_type {
             types::ContractData::RentContract(rc) => {
@@ -949,14 +943,14 @@ impl<T: Config> Pallet<T> {
                     match state {
                         types::ContractState::Created => {
                             Self::deposit_event(Event::ContractGracePeriodEnded {
-                                contract_id: ctr.contract_id,
+                                contract_id: ctr_id,
                                 node_id: rc.node_id,
                                 twin_id: ctr.twin_id,
                             });
                         }
-                        types::ContractState::GracePeriod(_) => {
+                        types::ContractState::GracePeriod(block_number) => {
                             Self::deposit_event(Event::ContractGracePeriodStarted {
-                                contract_id: ctr.contract_id,
+                                contract_id: ctr_id,
                                 node_id: rc.node_id,
                                 twin_id: ctr.twin_id,
                                 block_number,


### PR DESCRIPTION
When rent contract enters grace period, all associated node contracts are also set to grace period state in order for ZOS to pause these workloads. The reverse is done when the user adds funds to his wallet.