### PR TITLE
fix: canceling contract can result in error #397

### DIFF
--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -272,6 +272,10 @@ pub fn charlie() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("Charlie")
 }
 
+pub fn dave() -> AccountId {
+    get_account_id_from_seed::<sr25519::Public>("Dave")
+}
+
 pub fn get_staking_pool_account() -> AccountId {
     AccountId32::from_ss58check("5CNposRewardAccount11111111111111111111111111FSU").unwrap()
 }


### PR DESCRIPTION
- Does not move cancel contracts to grace period state if the user doesn't have enough balance
- Makes sure that only the amount available on the user's account get's billed