### PR TITLE
feat: add farm / nodes index

### DIFF
--- a/substrate-node/pallets/pallet-tfgrid/src/grid_migration.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/grid_migration.rs
@@ -88,7 +88,7 @@ pub mod deprecated {
     }
 }
 
-pub mod v6 {
+pub mod v7 {
     use super::*;
     use crate::Config;
 
@@ -111,7 +111,7 @@ pub mod v6 {
 
         #[cfg(feature = "try-runtime")]
         fn post_upgrade() -> Result<(), &'static str> {
-            assert!(PalletVersion::<T>::get() == types::StorageVersion::V6Struct);
+            assert!(PalletVersion::<T>::get() == types::StorageVersion::V7Struct);
 
             info!(
                 "👥  TFGrid pallet migration to {:?} passes POST migrate checks ✅",
@@ -262,7 +262,7 @@ pub fn migrate_farms<T: Config>() -> frame_support::weights::Weight {
     );
 
     // Update pallet storage version
-    PalletVersion::<T>::set(types::StorageVersion::V6Struct);
+    PalletVersion::<T>::set(types::StorageVersion::V7Struct);
     info!(" <<< Storage version upgraded");
 
     // Return the weight consumed by the migration.

--- a/substrate-node/pallets/pallet-tfgrid/src/grid_migration.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/grid_migration.rs
@@ -190,6 +190,11 @@ pub fn migrate_nodes<T: Config>() -> frame_support::weights::Weight {
             connection_price: node.connection_price,
         };
 
+        // Add index of farm - list (nodes)
+        let mut nodes_by_farm_id = NodesByFarmID::<T>::get(node.farm_id);
+        nodes_by_farm_id.push(node.id);
+        NodesByFarmID::<T>::insert(node.farm_id, nodes_by_farm_id);
+
         migrated_count += 1;
 
         Some(new_node)

--- a/substrate-node/pallets/pallet-tfgrid/src/grid_migration.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/grid_migration.rs
@@ -8,6 +8,7 @@ use frame_support::{
     weights::Weight,
 };
 use log::info;
+use sp_std::collections::btree_map::BTreeMap;
 use tfchain_support::types::{Farm, Interface, PublicConfig, PublicIP, IP};
 
 pub mod deprecated {
@@ -136,6 +137,9 @@ pub fn migrate_nodes<T: Config>() -> frame_support::weights::Weight {
     info!(" >>> Migrating nodes storage...");
 
     let mut migrated_count = 0;
+    let mut writes = 0;
+    let mut farms_with_nodes: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
+
     // We transform the storage values from the old into the new format.
     Nodes::<T>::translate::<deprecated::NodeV4, _>(|k, node| {
         info!("     Migrated node for {:?}...", k);
@@ -191,9 +195,10 @@ pub fn migrate_nodes<T: Config>() -> frame_support::weights::Weight {
         };
 
         // Add index of farm - list (nodes)
-        let mut nodes_by_farm_id = NodesByFarmID::<T>::get(node.farm_id);
-        nodes_by_farm_id.push(node.id);
-        NodesByFarmID::<T>::insert(node.farm_id, nodes_by_farm_id);
+        farms_with_nodes
+            .entry(node.farm_id)
+            .or_insert(vec![])
+            .push(node.id);
 
         migrated_count += 1;
 
@@ -204,8 +209,16 @@ pub fn migrate_nodes<T: Config>() -> frame_support::weights::Weight {
         migrated_count
     );
 
+    for (farm_id, nodes) in farms_with_nodes.iter() {
+        NodesByFarmID::<T>::insert(farm_id, nodes);
+        writes += 1;
+    }
+
     // Return the weight consumed by the migration.
-    T::DbWeight::get().reads_writes(migrated_count as Weight + 1, migrated_count as Weight + 1)
+    T::DbWeight::get().reads_writes(
+        migrated_count as Weight + 1,
+        migrated_count + writes as Weight + 1,
+    )
 }
 
 pub fn migrate_farms<T: Config>() -> frame_support::weights::Weight {

--- a/substrate-node/pallets/pallet-tfgrid/src/lib.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/lib.rs
@@ -1851,7 +1851,9 @@ pub mod pallet {
                 let now = system::Pallet::<T>::block_number();
 
                 // Policy end is expressed in number of blocks
-                if now >= farming_policy.policy_created + farming_policy.policy_end {
+                if farming_policy.policy_end != T::BlockNumber::from(0 as u32)
+                    && now >= farming_policy.policy_created + farming_policy.policy_end
+                {
                     return Err(DispatchErrorWithPostInfo::from(
                         Error::<T>::FarmingPolicyExpired,
                     ));

--- a/substrate-node/pallets/pallet-tfgrid/src/lib.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/lib.rs
@@ -29,8 +29,8 @@ pub mod types;
 
 pub mod farm;
 pub mod grid_migration;
-pub mod nodes_migration;
 pub mod interface;
+pub mod nodes_migration;
 pub mod pub_config;
 pub mod pub_ip;
 pub mod twin;
@@ -1144,8 +1144,7 @@ pub mod pallet {
             let mut nodes_by_farm = NodesByFarmID::<T>::get(stored_node.farm_id);
             let location = nodes_by_farm
                 .binary_search(&id)
-                .ok()
-                .ok_or(Error::<T>::NodeNotExists)?;
+                .or(Err(Error::<T>::NodeNotExists))?;
             nodes_by_farm.remove(location);
             NodesByFarmID::<T>::insert(stored_node.farm_id, nodes_by_farm);
 
@@ -1667,8 +1666,7 @@ pub mod pallet {
             let mut nodes_by_farm = NodesByFarmID::<T>::get(node.farm_id);
             let location = nodes_by_farm
                 .binary_search(&node_id)
-                .ok()
-                .ok_or(Error::<T>::NodeNotExists)?;
+                .or(Err(Error::<T>::NodeNotExists))?;
             nodes_by_farm.remove(location);
             NodesByFarmID::<T>::insert(node.farm_id, nodes_by_farm);
 

--- a/substrate-node/pallets/pallet-tfgrid/src/lib.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/lib.rs
@@ -29,6 +29,7 @@ pub mod types;
 
 pub mod farm;
 pub mod grid_migration;
+pub mod nodes_migration;
 pub mod interface;
 pub mod pub_config;
 pub mod pub_ip;

--- a/substrate-node/pallets/pallet-tfgrid/src/nodes_migration.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/nodes_migration.rs
@@ -1,0 +1,62 @@
+use super::Config;
+use super::*;
+use frame_support::{traits::Get, weights::Weight};
+use log::info;
+
+pub mod v6 {
+    use super::*;
+    use crate::Config;
+
+    use frame_support::{pallet_prelude::Weight, traits::OnRuntimeUpgrade};
+    use sp_std::marker::PhantomData;
+    pub struct GridMigration<T: Config>(PhantomData<T>);
+
+    impl<T: Config> OnRuntimeUpgrade for GridMigration<T> {
+        #[cfg(feature = "try-runtime")]
+        fn pre_upgrade() -> Result<(), &'static str> {
+            assert!(PalletVersion::<T>::get() == types::StorageVersion::V6Struct);
+
+            info!("👥  TFGrid pallet to v4 passes PRE migrate checks ✅",);
+            Ok(())
+        }
+
+        fn on_runtime_upgrade() -> Weight {
+            if PalletVersion::<T>::get() == types::StorageVersion::V6Struct {
+                add_farm_nodes_index::<T>()
+            } else {
+                info!(" >>> Unused migration");
+                return 0;
+            }
+        }
+
+        #[cfg(feature = "try-runtime")]
+        fn post_upgrade() -> Result<(), &'static str> {
+            assert!(PalletVersion::<T>::get() == types::StorageVersion::V7Struct);
+
+            info!(
+                "👥  TFGrid pallet migration to {:?} passes POST migrate checks ✅",
+                Pallet::<T>::pallet_version()
+            );
+
+            Ok(())
+        }
+    }
+}
+
+pub fn add_farm_nodes_index<T: Config>() -> frame_support::weights::Weight {
+    info!(" >>> Migrating nodes storage...");
+
+    let mut reads = 0;
+
+    for (_, node) in Nodes::<T>::iter() {
+        // Add index of farm - list (nodes)
+        let mut nodes_by_farm_id = NodesByFarmID::<T>::get(node.farm_id);
+        nodes_by_farm_id.push(node.id);
+        NodesByFarmID::<T>::insert(node.farm_id, nodes_by_farm_id);
+
+        reads += 1;
+    }
+
+    // Return the weight consumed by the migration.
+    T::DbWeight::get().reads_writes(reads as Weight + 1, 0)
+}

--- a/substrate-node/pallets/pallet-tfgrid/src/nodes_migration.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/nodes_migration.rs
@@ -2,6 +2,7 @@ use super::Config;
 use super::*;
 use frame_support::{traits::Get, weights::Weight};
 use log::info;
+use sp_std::collections::btree_map::BTreeMap;
 
 pub mod v7patch {
     use super::*;
@@ -47,14 +48,22 @@ pub fn add_farm_nodes_index<T: Config>() -> frame_support::weights::Weight {
     info!(" >>> Migrating nodes storage...");
 
     let mut reads = 0;
+    let mut writes = 0;
 
+    let mut farms_with_nodes: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
     for (_, node) in Nodes::<T>::iter() {
         // Add index of farm - list (nodes)
-        let mut nodes_by_farm_id = NodesByFarmID::<T>::get(node.farm_id);
-        nodes_by_farm_id.push(node.id);
-        NodesByFarmID::<T>::insert(node.farm_id, nodes_by_farm_id);
+        farms_with_nodes
+            .entry(node.farm_id)
+            .or_insert(vec![])
+            .push(node.id);
 
         reads += 1;
+    }
+
+    for (farm_id, nodes) in farms_with_nodes.iter() {
+        NodesByFarmID::<T>::insert(farm_id, nodes);
+        writes += 1;
     }
 
     // Update pallet storage version
@@ -62,5 +71,5 @@ pub fn add_farm_nodes_index<T: Config>() -> frame_support::weights::Weight {
     info!(" <<< Storage version upgraded");
 
     // Return the weight consumed by the migration.
-    T::DbWeight::get().reads_writes(reads as Weight + 1, 0)
+    T::DbWeight::get().reads_writes(reads as Weight + 1, writes as Weight + 1)
 }

--- a/substrate-node/pallets/pallet-tfgrid/src/nodes_migration.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/nodes_migration.rs
@@ -3,15 +3,15 @@ use super::*;
 use frame_support::{traits::Get, weights::Weight};
 use log::info;
 
-pub mod v6 {
+pub mod v7patch {
     use super::*;
     use crate::Config;
 
     use frame_support::{pallet_prelude::Weight, traits::OnRuntimeUpgrade};
     use sp_std::marker::PhantomData;
-    pub struct GridMigration<T: Config>(PhantomData<T>);
+    pub struct NodesMigration<T: Config>(PhantomData<T>);
 
-    impl<T: Config> OnRuntimeUpgrade for GridMigration<T> {
+    impl<T: Config> OnRuntimeUpgrade for NodesMigration<T> {
         #[cfg(feature = "try-runtime")]
         fn pre_upgrade() -> Result<(), &'static str> {
             assert!(PalletVersion::<T>::get() == types::StorageVersion::V6Struct);
@@ -56,6 +56,10 @@ pub fn add_farm_nodes_index<T: Config>() -> frame_support::weights::Weight {
 
         reads += 1;
     }
+
+    // Update pallet storage version
+    PalletVersion::<T>::set(types::StorageVersion::V7Struct);
+    info!(" <<< Storage version upgraded");
 
     // Return the weight consumed by the migration.
     T::DbWeight::get().reads_writes(reads as Weight + 1, 0)

--- a/substrate-node/pallets/pallet-tfgrid/src/tests.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/tests.rs
@@ -179,7 +179,14 @@ fn test_delete_node_works() {
         create_farm();
         create_node();
 
+        let nodes = TfgridModule::nodes_by_farm_id(1);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0], 1);
+
         assert_ok!(TfgridModule::delete_node_farm(Origin::signed(alice()), 1));
+
+        let nodes = TfgridModule::nodes_by_farm_id(1);
+        assert_eq!(nodes.len(), 0);
     });
 }
 
@@ -633,6 +640,20 @@ fn create_node_works() {
         create_twin();
         create_farm();
         create_node();
+    });
+}
+
+#[test]
+fn create_node_added_to_farm_list_works() {
+    ExternalityBuilder::build().execute_with(|| {
+        create_entity();
+        create_twin();
+        create_farm();
+        create_node();
+
+        let nodes = TfgridModule::nodes_by_farm_id(1);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0], 1);
     });
 }
 
@@ -1507,26 +1528,26 @@ fn test_create_and_update_policy() {
 }
 
 #[test]
- fn test_set_zos_version() {
-     ExternalityBuilder::build().execute_with(|| {
-         let zos_version = "1.0.0".as_bytes().to_vec();
-         assert_ok!(TfgridModule::set_zos_version(
-             RawOrigin::Root.into(),
-             zos_version.clone(),
-         ));
+fn test_set_zos_version() {
+    ExternalityBuilder::build().execute_with(|| {
+        let zos_version = "1.0.0".as_bytes().to_vec();
+        assert_ok!(TfgridModule::set_zos_version(
+            RawOrigin::Root.into(),
+            zos_version.clone(),
+        ));
 
-         let saved_zos_version = TfgridModule::zos_version();
-         assert_eq!(saved_zos_version, zos_version);
+        let saved_zos_version = TfgridModule::zos_version();
+        assert_eq!(saved_zos_version, zos_version);
 
-         let our_events = System::events();
-         assert_eq!(
-             our_events.contains(&record(MockEvent::TfgridModule(
-                 TfgridEvent::<TestRuntime>::ZosVersionUpdated(zos_version)
-             ))),
-             true
-         );
-     })
- }
+        let our_events = System::events();
+        assert_eq!(
+            our_events.contains(&record(MockEvent::TfgridModule(
+                TfgridEvent::<TestRuntime>::ZosVersionUpdated(zos_version)
+            ))),
+            true
+        );
+    })
+}
 
 fn create_entity() {
     let name = "foobar".as_bytes().to_vec();

--- a/substrate-node/pallets/pallet-tfgrid/src/types.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/types.rs
@@ -13,6 +13,7 @@ pub enum StorageVersion {
     V4Struct,
     V5Struct,
     V6Struct,
+    V7Struct
 }
 
 impl Default for StorageVersion {

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -746,7 +746,8 @@ pub type Executive = frame_executive::Executive<
     AllPalletsWithSystem,
     (
         pallet_smart_contract::contract_migration::v5::ContractMigrationV5<Runtime>,
-        pallet_tfgrid::grid_migration::v6::GridMigration<Runtime>,
+        pallet_tfgrid::grid_migration::v7::GridMigration<Runtime>,
+        pallet_tfgrid::nodes_migration::v7patch::NodesMigration<Runtime>,
     ),
 >;
 


### PR DESCRIPTION
Adds a new storage map `NodesByFarmID`, double map with key being the farm id and the value being a list of node ids. Allows for easier lookup between a farm and it's nodes. #405 

`grid_migration` now put's the storage version to V7 and checks if it comes from V5 (compatible with all other networks)
`node_migration` also put's the storage version to V7 but checks if it came from V6