### PR TITLE
chore: also save farm certification when policy is attached

### DIFF
--- a/substrate-node/pallets/pallet-tfgrid/src/lib.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/lib.rs
@@ -1059,9 +1059,12 @@ pub mod pallet {
 
                 stored_node.certification = node_certification;
 
-                // Refetch farming policy and save it on the node
-                let farming_policy = Self::get_farming_policy(&stored_node)?;
-                stored_node.farming_policy_id = farming_policy.id;
+                let current_node_policy = FarmingPoliciesMap::<T>::get(node.farming_policy_id);
+                if current_node_policy.default {
+                    // Refetch farming policy and save it on the node
+                    let farming_policy = Self::get_farming_policy(&stored_node)?;
+                    stored_node.farming_policy_id = farming_policy.id;
+                }
 
                 // override node in storage
                 Nodes::<T>::insert(stored_node.id, &stored_node);

--- a/substrate-node/pallets/pallet-tfgrid/src/lib.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/lib.rs
@@ -1860,9 +1860,11 @@ pub mod pallet {
                 }
 
                 let mut farm = Farms::<T>::get(farm_id).ok_or(Error::<T>::FarmNotExists)?;
-                farm.farming_policy_limits = Some(policy_limits);
+                farm.farming_policy_limits = Some(policy_limits.clone());
+                farm.certification = farming_policy.farm_certification;
                 Farms::<T>::insert(farm_id, &farm);
-                Self::deposit_event(Event::FarmingPolicySet(farm_id, farm.farming_policy_limits));
+                Self::deposit_event(Event::FarmingPolicySet(farm_id, Some(policy_limits)));
+                Self::deposit_event(Event::FarmUpdated(farm))
             }
 
             Ok(().into())

--- a/substrate-node/pallets/pallet-tfgrid/src/lib.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/lib.rs
@@ -1860,6 +1860,7 @@ pub mod pallet {
                 }
 
                 let mut farm = Farms::<T>::get(farm_id).ok_or(Error::<T>::FarmNotExists)?;
+                // Save the policy limits and farm certification on the Farm object
                 farm.farming_policy_limits = Some(policy_limits.clone());
                 farm.certification = farming_policy.farm_certification;
                 Farms::<T>::insert(farm_id, &farm);
@@ -1875,7 +1876,9 @@ pub mod pallet {
                             // because we wouldn't wanna override any existing non-default policies
                             if current_node_policy.default {
                                 let policy = Self::get_farming_policy(&node)?;
+                                // Save the new policy ID and certification on the Node object
                                 node.farming_policy_id = policy.id;
+                                node.certification = policy.node_certification;
                                 Nodes::<T>::insert(node_id, &node);
                                 Self::deposit_event(Event::NodeUpdated(node))
                             }


### PR DESCRIPTION
Also save certifcation level on 

- Farm
- Nodes (this way we don't have to manually toggle to them to certification level attached to the policy)