### PR TITLE
fix: validation of node pub config/interfaces/ips

### DIFF
--- a/substrate-node/Cargo.lock
+++ b/substrate-node/Cargo.lock
@@ -7943,9 +7943,9 @@ dependencies = [
 
 [[package]]
 name = "valip"
-version = "0.3.0-rc2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4963d7dcb64348a5473a201d759b8342c32ecf5b72482b75d05e0c3ddefb18fe"
+checksum = "19bff85cc0b5bf6728a74934372fc925cbbb4433116f25aa3351f417e089cf79"
 
 [[package]]
 name = "valuable"

--- a/substrate-node/pallets/pallet-dao/src/mock.rs
+++ b/substrate-node/pallets/pallet-dao/src/mock.rs
@@ -110,6 +110,8 @@ impl pallet_dao::Config for Test {
 parameter_types! {
     pub const MaxFarmNameLength: u32 = 40;
     pub const MaxInterfaceIpsLength: u32 = 5;
+    pub const MaxInterfacesLength: u32 = 10;
+    pub const MaxFarmPublicIps: u32 = 512;
 }
 
 pub(crate) type TestTwinIp = TwinIp<Test>;
@@ -135,6 +137,7 @@ impl pallet_tfgrid::Config for Test {
     type TwinIp = TestTwinIp;
     type FarmName = TestFarmName;
     type MaxFarmNameLength = MaxFarmNameLength;
+    type MaxFarmPublicIps = MaxFarmPublicIps;
     type PublicIP = TestPublicIP;
     type GatewayIP = TestGatewayIP;
     type IP4 = TestIP4;
@@ -142,6 +145,7 @@ impl pallet_tfgrid::Config for Test {
     type IP6 = TestIP6;
     type GW6 = TestGW6;
     type Domain = TestDomain;
+    type MaxInterfacesLength = MaxInterfacesLength;
     type InterfaceName = TestInterfaceName;
     type InterfaceMac = TestInterfaceMac;
     type InterfaceIP = TestInterfaceIp;

--- a/substrate-node/pallets/pallet-dao/src/tests.rs
+++ b/substrate-node/pallets/pallet-dao/src/tests.rs
@@ -1,11 +1,12 @@
 use super::Event as DaoEvent;
 use crate::{mock::Event as MockEvent, mock::*, Error};
-use frame_support::{assert_noop, assert_ok, weights::GetDispatchInfo};
+use frame_support::{assert_noop, assert_ok, bounded_vec, weights::GetDispatchInfo};
 use frame_system::{EventRecord, Phase, RawOrigin};
+use pallet_tfgrid::types::PublicIpInput;
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, Hash};
 use std::convert::TryInto;
-use tfchain_support::types::{FarmCertification, Location, NodeCertification, PublicIP, Resources};
+use tfchain_support::types::{FarmCertification, Location, NodeCertification, Resources};
 
 #[test]
 fn farmers_vote_no_farm_fails() {
@@ -810,7 +811,7 @@ fn prepare_node(account_id: u64, farm_id: u32) {
         location,
         country,
         city,
-        Vec::new(),
+        bounded_vec![],
         false,
         false,
         "some_serial".as_bytes().to_vec(),
@@ -840,7 +841,7 @@ fn prepare_big_node(account_id: u64, farm_id: u32) {
         location,
         country,
         city,
-        Vec::new(),
+        bounded_vec![],
         false,
         false,
         "some_serial".as_bytes().to_vec(),
@@ -849,16 +850,15 @@ fn prepare_big_node(account_id: u64, farm_id: u32) {
 
 pub fn prepare_farm(account_id: u64, farm_name: Vec<u8>) {
     let mut pub_ips = Vec::new();
-    pub_ips.push(PublicIP {
+    pub_ips.push(PublicIpInput {
         ip: "185.206.122.33/24".as_bytes().to_vec().try_into().unwrap(),
-        gateway: "185.206.122.1".as_bytes().to_vec().try_into().unwrap(),
-        contract_id: 0,
+        gw: "185.206.122.1".as_bytes().to_vec().try_into().unwrap(),
     });
 
     assert_ok!(TfgridModule::create_farm(
         Origin::signed(account_id),
         farm_name.try_into().unwrap(),
-        pub_ips.clone(),
+        pub_ips.clone().try_into().unwrap(),
     ));
 }
 

--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -123,6 +123,8 @@ impl ChangeNode<PubConfig, Interface> for NodeChanged {
 parameter_types! {
     pub const MaxFarmNameLength: u32 = 40;
     pub const MaxInterfaceIpsLength: u32 = 5;
+    pub const MaxInterfacesLength: u32 = 10;
+    pub const MaxFarmPublicIps: u32 = 512;
 }
 
 pub(crate) type TestTwinIp = TwinIp<TestRuntime>;
@@ -148,6 +150,7 @@ impl pallet_tfgrid::Config for TestRuntime {
     type TwinIp = TestTwinIp;
     type FarmName = TestFarmName;
     type MaxFarmNameLength = MaxFarmNameLength;
+    type MaxFarmPublicIps = MaxFarmPublicIps;
     type PublicIP = TestPublicIP;
     type GatewayIP = TestGatewayIP;
     type IP4 = TestIP4;
@@ -155,6 +158,7 @@ impl pallet_tfgrid::Config for TestRuntime {
     type IP6 = TestIP6;
     type GW6 = TestGW6;
     type Domain = TestDomain;
+    type MaxInterfacesLength = MaxInterfacesLength;
     type InterfaceName = TestInterfaceName;
     type InterfaceMac = TestInterfaceMac;
     type InterfaceIP = TestInterfaceIp;

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -1,7 +1,7 @@
 use super::Event as SmartContractEvent;
 use crate::{mock::Event as MockEvent, mock::*, Error};
 use frame_support::{
-    assert_noop, assert_ok,
+    assert_noop, assert_ok, bounded_vec,
     traits::{LockableCurrency, OnFinalize, OnInitialize, WithdrawReasons},
     BoundedVec,
 };
@@ -2350,10 +2350,9 @@ pub fn prepare_twins() {
 pub fn prepare_farm(source: AccountId, dedicated: bool) {
     let farm_name = "test_farm";
     let mut pub_ips = Vec::new();
-    pub_ips.push(PublicIP {
+    pub_ips.push(pallet_tfgrid_types::PublicIpInput {
         ip: "185.206.122.33/24".as_bytes().to_vec().try_into().unwrap(),
-        gateway: "185.206.122.1".as_bytes().to_vec().try_into().unwrap(),
-        contract_id: 0,
+        gw: "185.206.122.1".as_bytes().to_vec().try_into().unwrap(),
     });
 
     let su_policy = pallet_tfgrid_types::Policy {
@@ -2399,7 +2398,7 @@ pub fn prepare_farm(source: AccountId, dedicated: bool) {
     TfgridModule::create_farm(
         Origin::signed(source),
         farm_name.as_bytes().to_vec().try_into().unwrap(),
-        pub_ips.clone(),
+        pub_ips.clone().try_into().unwrap(),
     )
     .unwrap();
 
@@ -2441,7 +2440,7 @@ pub fn prepare_farm_and_node() {
         location,
         country,
         city,
-        Vec::new(),
+        bounded_vec![],
         false,
         false,
         "some_serial".as_bytes().to_vec(),
@@ -2479,7 +2478,7 @@ pub fn prepare_dedicated_farm_and_node() {
         location,
         country,
         city,
-        Vec::new(),
+        bounded_vec![],
         false,
         false,
         "some_serial".as_bytes().to_vec(),

--- a/substrate-node/pallets/pallet-tfgrid/Cargo.toml
+++ b/substrate-node/pallets/pallet-tfgrid/Cargo.toml
@@ -23,7 +23,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 ] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 tfchain-support = { path = "../../support", default-features = false }
-valip = "0.3.0-rc2"
+valip = "0.3.0"
 
 frame-benchmarking =  { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", default-features = false, optional = true }
 pallet-balances =  { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", default-features = false }

--- a/substrate-node/pallets/pallet-tfgrid/src/interface.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/interface.rs
@@ -5,7 +5,7 @@ use frame_support::{
     ensure, sp_runtime::SaturatedConversion, traits::ConstU32, BoundedVec, RuntimeDebug,
 };
 use scale_info::TypeInfo;
-use valip::{ip4::Ip, ip6::Ip as IPv6, mac::Mac};
+use valip::{ip4::Ip as IPv4, ip6::Ip as IPv6, mac::Mac};
 
 use crate::{Config, Error};
 
@@ -136,7 +136,7 @@ impl<T: Config> TryFrom<Vec<u8>> for InterfaceIp<T> {
         let bounded_vec: BoundedVec<u8, ConstU32<MAX_INTERFACE_IP_LENGTH>> =
             BoundedVec::try_from(value).map_err(|_| Self::Error::InterfaceIpToLong)?;
         ensure!(
-            Ip::parse(&bounded_vec).is_ok() || IPv6::parse(&bounded_vec).is_ok(),
+            IPv4::parse(&bounded_vec).is_ok() || IPv6::parse(&bounded_vec).is_ok(),
             Self::Error::InvalidInterfaceIP
         );
         Ok(Self(bounded_vec, PhantomData))

--- a/substrate-node/pallets/pallet-tfgrid/src/interface.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/interface.rs
@@ -5,7 +5,7 @@ use frame_support::{
     ensure, sp_runtime::SaturatedConversion, traits::ConstU32, BoundedVec, RuntimeDebug,
 };
 use scale_info::TypeInfo;
-use valip::{ip4::ip::IPv4, ip6::Ip as IPv6, mac::Mac};
+use valip::{ip4::Ip, ip6::Ip as IPv6, mac::Mac};
 
 use crate::{Config, Error};
 
@@ -136,7 +136,7 @@ impl<T: Config> TryFrom<Vec<u8>> for InterfaceIp<T> {
         let bounded_vec: BoundedVec<u8, ConstU32<MAX_INTERFACE_IP_LENGTH>> =
             BoundedVec::try_from(value).map_err(|_| Self::Error::InterfaceIpToLong)?;
         ensure!(
-            IPv4::parse(&bounded_vec).is_ok() || IPv6::parse(&bounded_vec).is_ok(),
+            Ip::parse(&bounded_vec).is_ok() || IPv6::parse(&bounded_vec).is_ok(),
             Self::Error::InvalidInterfaceIP
         );
         Ok(Self(bounded_vec, PhantomData))

--- a/substrate-node/pallets/pallet-tfgrid/src/mock.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/mock.rs
@@ -95,6 +95,7 @@ impl tfchain_support::traits::ChangeNode<PubConfig, Interface> for NodeChanged {
 parameter_types! {
     pub const MaxFarmNameLength: u32 = 40;
     pub const MaxInterfaceIpsLength: u32 = 5;
+    pub const MaxInterfacesLength: u32 = 10;
 }
 
 pub(crate) type TestTwinIp = TwinIp<TestRuntime>;
@@ -130,6 +131,7 @@ impl Config for TestRuntime {
     type InterfaceName = TestInterfaceName;
     type InterfaceMac = TestInterfaceMac;
     type InterfaceIP = TestInterfaceIp;
+    type MaxInterfacesLength = MaxInterfacesLength;
     type MaxInterfaceIpsLength = MaxInterfaceIpsLength;
 }
 

--- a/substrate-node/pallets/pallet-tfgrid/src/mock.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/mock.rs
@@ -96,6 +96,7 @@ parameter_types! {
     pub const MaxFarmNameLength: u32 = 40;
     pub const MaxInterfaceIpsLength: u32 = 5;
     pub const MaxInterfacesLength: u32 = 10;
+    pub const MaxFarmPublicIps: u32 = 512;
 }
 
 pub(crate) type TestTwinIp = TwinIp<TestRuntime>;
@@ -121,6 +122,7 @@ impl Config for TestRuntime {
     type TwinIp = TestTwinIp;
     type FarmName = TestFarmName;
     type MaxFarmNameLength = MaxFarmNameLength;
+    type MaxFarmPublicIps = MaxFarmPublicIps;
     type PublicIP = TestPublicIP;
     type GatewayIP = TestGatewayIP;
     type IP4 = TestIP4;

--- a/substrate-node/pallets/pallet-tfgrid/src/pub_config.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/pub_config.rs
@@ -149,15 +149,17 @@ impl<T: Config> Clone for IP6<T> {
     }
 }
 
-/// A Public Config IP6
-/// Needs to be valid format (ipv6 without cidr)
+/// A Public Config IP6 gateway
+/// Needs to be valid format (ipv6 without CIDR)
 #[derive(Encode, Decode, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
 #[codec(mel_bound())]
 pub struct GW6<T: Config>(
-    pub BoundedVec<u8, ConstU32<MAX_IP6_LENGTH>>,
-    PhantomData<(T, ConstU32<MAX_IP6_LENGTH>)>,
+    pub BoundedVec<u8, ConstU32<MAX_GW6_LENGTH>>,
+    PhantomData<(T, ConstU32<MAX_GW6_LENGTH>)>,
 );
+
+pub const MAX_GW6_LENGTH: u32 = 39;
 
 impl<T: Config> TryFrom<Vec<u8>> for GW6<T> {
     type Error = Error<T>;
@@ -170,7 +172,7 @@ impl<T: Config> TryFrom<Vec<u8>> for GW6<T> {
             value.len() >= MIN_IP6_LENGHT.saturated_into(),
             Self::Error::GW6ToShort
         );
-        let bounded_vec: BoundedVec<u8, ConstU32<MAX_IP6_LENGTH>> =
+        let bounded_vec: BoundedVec<u8, ConstU32<MAX_GW6_LENGTH>> =
             BoundedVec::try_from(value).map_err(|_| Self::Error::GW6ToLong)?;
         ensure!(IPv6::parse(&bounded_vec).is_ok(), Self::Error::InvalidGW6);
         Ok(Self(bounded_vec, PhantomData))

--- a/substrate-node/pallets/pallet-tfgrid/src/pub_config.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/pub_config.rs
@@ -7,7 +7,7 @@ use frame_support::{
 };
 use scale_info::TypeInfo;
 use valip::{
-    ip4::{cidr::CIDR, ip::IPv4},
+    ip4::{Ip, CIDR},
     ip6::{Ip as IPv6, CIDR as IPv6Cidr},
 };
 
@@ -82,7 +82,7 @@ impl<T: Config> TryFrom<Vec<u8>> for GW4<T> {
         );
         let bounded_vec: BoundedVec<u8, ConstU32<MAX_GATEWAY_LENGTH>> =
             BoundedVec::try_from(value).map_err(|_| Self::Error::GW4ToLong)?;
-        ensure!(IPv4::parse(&bounded_vec).is_ok(), Self::Error::InvalidGW4);
+        ensure!(Ip::parse(&bounded_vec).is_ok(), Self::Error::InvalidGW4);
         Ok(Self(bounded_vec, PhantomData))
     }
 }

--- a/substrate-node/pallets/pallet-tfgrid/src/pub_config.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/pub_config.rs
@@ -7,7 +7,7 @@ use frame_support::{
 };
 use scale_info::TypeInfo;
 use valip::{
-    ip4::{Ip, CIDR},
+    ip4::{Ip as IPv4, CIDR as IPv4Cidr},
     ip6::{Ip as IPv6, CIDR as IPv6Cidr},
 };
 
@@ -37,7 +37,10 @@ impl<T: Config> TryFrom<Vec<u8>> for IP4<T> {
         );
         let bounded_vec: BoundedVec<u8, ConstU32<MAX_IP_LENGTH>> =
             BoundedVec::try_from(value).map_err(|_| Self::Error::IP4ToLong)?;
-        ensure!(CIDR::parse(&bounded_vec).is_ok(), Self::Error::InvalidIP4);
+        ensure!(
+            IPv4Cidr::parse(&bounded_vec).is_ok(),
+            Self::Error::InvalidIP4
+        );
         Ok(Self(bounded_vec, PhantomData))
     }
 }
@@ -82,7 +85,7 @@ impl<T: Config> TryFrom<Vec<u8>> for GW4<T> {
         );
         let bounded_vec: BoundedVec<u8, ConstU32<MAX_GATEWAY_LENGTH>> =
             BoundedVec::try_from(value).map_err(|_| Self::Error::GW4ToLong)?;
-        ensure!(Ip::parse(&bounded_vec).is_ok(), Self::Error::InvalidGW4);
+        ensure!(IPv4::parse(&bounded_vec).is_ok(), Self::Error::InvalidGW4);
         Ok(Self(bounded_vec, PhantomData))
     }
 }

--- a/substrate-node/pallets/pallet-tfgrid/src/pub_ip.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/pub_ip.rs
@@ -5,7 +5,7 @@ use frame_support::{
     ensure, sp_runtime::SaturatedConversion, traits::ConstU32, BoundedVec, RuntimeDebug,
 };
 use scale_info::TypeInfo;
-use valip::ip4::{cidr::CIDR, ip::IPv4};
+use valip::ip4::{Ip, CIDR};
 
 use crate::{Config, Error};
 
@@ -84,7 +84,7 @@ impl<T: Config> TryFrom<Vec<u8>> for GatewayIP<T> {
         let bounded_vec: BoundedVec<u8, ConstU32<MAX_GATEWAY_LENGTH>> =
             BoundedVec::try_from(value).map_err(|_| Self::Error::GatewayIPToLong)?;
         ensure!(
-            IPv4::parse(&bounded_vec).is_ok(),
+            Ip::parse(&bounded_vec).is_ok(),
             Self::Error::InvalidPublicIP
         );
         Ok(Self(bounded_vec, PhantomData))

--- a/substrate-node/pallets/pallet-tfgrid/src/types.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/types.rs
@@ -13,7 +13,7 @@ pub enum StorageVersion {
     V4Struct,
     V5Struct,
     V6Struct,
-    V7Struct
+    V7Struct,
 }
 
 impl Default for StorageVersion {
@@ -181,4 +181,10 @@ pub struct TermsAndConditions<AccountId> {
     pub timestamp: u64,
     pub document_link: Vec<u8>,
     pub document_hash: Vec<u8>,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default, Debug, TypeInfo)]
+pub struct PublicIpInput<IP, GW> {
+    pub ip: IP,
+    pub gw: GW,
 }

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -341,6 +341,8 @@ impl ChangeNode<PubConfig, Interface> for NodeChanged {
 parameter_types! {
     pub const MaxFarmNameLength: u32 = 40;
     pub const MaxInterfaceIpsLength: u32 = 10;
+    pub const MaxInterfacesLength: u32 = 10;
+    pub const MaxFarmPublicIps: u32 = 512;
 }
 
 impl pallet_tfgrid::Config for Runtime {
@@ -350,6 +352,7 @@ impl pallet_tfgrid::Config for Runtime {
     type NodeChanged = NodeChanged;
     type TwinIp = pallet_tfgrid::twin::TwinIp<Runtime>;
     type MaxFarmNameLength = MaxFarmNameLength;
+    type MaxFarmPublicIps = MaxFarmPublicIps;
     type FarmName = pallet_tfgrid::farm::FarmName<Runtime>;
     type PublicIP = pallet_tfgrid::pub_ip::PublicIP<Runtime>;
     type GatewayIP = pallet_tfgrid::pub_ip::GatewayIP<Runtime>;
@@ -358,6 +361,7 @@ impl pallet_tfgrid::Config for Runtime {
     type IP6 = pallet_tfgrid::pub_config::IP6<Runtime>;
     type GW6 = pallet_tfgrid::pub_config::GW6<Runtime>;
     type Domain = pallet_tfgrid::pub_config::Domain<Runtime>;
+    type MaxInterfacesLength = MaxInterfacesLength;
     type InterfaceName = pallet_tfgrid::interface::InterfaceName<Runtime>;
     type InterfaceMac = pallet_tfgrid::interface::InterfaceMac<Runtime>;
     type InterfaceIP = pallet_tfgrid::interface::InterfaceIp<Runtime>;


### PR DESCRIPTION
Sadly, when using a type that has validation implemented it's not automaticaly checked when provided to an extrinsic. An input type is needed to convert from the input to the exact type where then validation occurs.

also use latest `valip` version