### PR TITLE
feat: allow setting bounds for avg tft price

### DIFF
--- a/substrate-node/node/src/chain_spec.rs
+++ b/substrate-node/node/src/chain_spec.rs
@@ -117,6 +117,8 @@ pub fn development_config() -> Result<ChainSpec, String> {
 			get_account_id_from_seed::<sr25519::Public>("Ferdie"),
 			// TFT price pallet allow account
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
+            // TFT price pallet min price
+            30,
 		)
         },
         // Bootnodes
@@ -201,6 +203,8 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 			get_account_id_from_seed::<sr25519::Public>("Ferdie"),
 			// TFT price pallet allow account
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
+            // TFT price pallet min price
+            30,
 		)
         },
         // Bootnodes
@@ -229,6 +233,7 @@ fn testnet_genesis(
     bridge_validator_accounts: Vec<AccountId>,
     bridge_fee_account: AccountId,
     tft_price_allowed_account: AccountId,
+    min_tft_price: u32,
 ) -> GenesisConfig {
     GenesisConfig {
         system: SystemConfig {
@@ -316,6 +321,7 @@ fn testnet_genesis(
         // just some default for development
         tft_price_module: TFTPriceModuleConfig {
             allowed_origin: Some(tft_price_allowed_account),
+            min_tft_price,
         },
     }
 }

--- a/substrate-node/node/src/chain_spec.rs
+++ b/substrate-node/node/src/chain_spec.rs
@@ -118,7 +118,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
 			// TFT price pallet allow account
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
             // TFT price pallet min price
-            30,
+            10,
 		)
         },
         // Bootnodes
@@ -204,7 +204,7 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 			// TFT price pallet allow account
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
             // TFT price pallet min price
-            30,
+            10,
 		)
         },
         // Bootnodes

--- a/substrate-node/node/src/chain_spec.rs
+++ b/substrate-node/node/src/chain_spec.rs
@@ -119,6 +119,8 @@ pub fn development_config() -> Result<ChainSpec, String> {
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
             // TFT price pallet min price
             10,
+            // TFT price pallet max price
+            1000,
 		)
         },
         // Bootnodes
@@ -205,6 +207,8 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
             // TFT price pallet min price
             10,
+            // TFT price pallet max price
+            1000,
 		)
         },
         // Bootnodes
@@ -234,6 +238,7 @@ fn testnet_genesis(
     bridge_fee_account: AccountId,
     tft_price_allowed_account: AccountId,
     min_tft_price: u32,
+    max_tft_price: u32,
 ) -> GenesisConfig {
     GenesisConfig {
         system: SystemConfig {
@@ -322,6 +327,7 @@ fn testnet_genesis(
         tft_price_module: TFTPriceModuleConfig {
             allowed_origin: Some(tft_price_allowed_account),
             min_tft_price,
+            max_tft_price,
         },
     }
 }

--- a/substrate-node/pallets/pallet-smart-contract/src/cost.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/cost.rs
@@ -4,7 +4,7 @@ use crate::pallet::Error;
 use crate::types;
 use crate::types::{Contract, ContractBillingInformation};
 use crate::Config;
-use frame_support::{dispatch::DispatchErrorWithPostInfo, ensure};
+use frame_support::dispatch::DispatchErrorWithPostInfo;
 use pallet_tfgrid::types as pallet_tfgrid_types;
 use sp_runtime::Percent;
 use sp_runtime::SaturatedConversion;
@@ -244,10 +244,15 @@ pub fn calculate_cost_in_tft_from_musd<T: Config>(
     total_cost: u64,
 ) -> Result<u64, DispatchErrorWithPostInfo> {
     let avg_tft_price = pallet_tft_price::AverageTftPrice::<T>::get();
-    ensure!(avg_tft_price > 0, Error::<T>::TFTPriceValueError);
+    let min_tft_price = pallet_tft_price::MinTftPrice::<T>::get();
+
+    let mut tft_price = avg_tft_price;
+    if avg_tft_price < min_tft_price {
+        tft_price = min_tft_price;
+    };
 
     // TFT Price is in musd
-    let tft_price_musd = U64F64::from_num(avg_tft_price);
+    let tft_price_musd = U64F64::from_num(tft_price);
 
     // Cost is expressed in units USD, divide by 10000 to get the price in musd
     let total_cost_musd = U64F64::from_num(total_cost) / 10000;

--- a/substrate-node/pallets/pallet-smart-contract/src/cost.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/cost.rs
@@ -244,12 +244,14 @@ pub fn calculate_cost_in_tft_from_musd<T: Config>(
     total_cost: u64,
 ) -> Result<u64, DispatchErrorWithPostInfo> {
     let avg_tft_price = pallet_tft_price::AverageTftPrice::<T>::get();
-    let min_tft_price = pallet_tft_price::MinTftPrice::<T>::get();
 
-    let mut tft_price = avg_tft_price;
-    if avg_tft_price < min_tft_price {
-        tft_price = min_tft_price;
-    };
+    // Guaranty tft price will never be lower than min tft price
+    let min_tft_price = pallet_tft_price::MinTftPrice::<T>::get();
+    let mut tft_price = avg_tft_price.max(min_tft_price);
+
+    // Guaranty tft price will never be higher than max tft price
+    let max_tft_price = pallet_tft_price::MaxTftPrice::<T>::get();
+    tft_price = tft_price.min(max_tft_price);
 
     // TFT Price is in musd
     let tft_price_musd = U64F64::from_num(tft_price);

--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -302,7 +302,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
     let genesis = pallet_tft_price::GenesisConfig::<TestRuntime> {
         allowed_origin: Some(bob()),
-        min_tft_price: 30,
+        min_tft_price: 10,
     };
     genesis.assimilate_storage(&mut t).unwrap();
 

--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -302,6 +302,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
     let genesis = pallet_tft_price::GenesisConfig::<TestRuntime> {
         allowed_origin: Some(bob()),
+        min_tft_price: 30,
     };
     genesis.assimilate_storage(&mut t).unwrap();
 

--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -303,6 +303,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     let genesis = pallet_tft_price::GenesisConfig::<TestRuntime> {
         allowed_origin: Some(bob()),
         min_tft_price: 10,
+        max_tft_price: 1000,
     };
     genesis.assimilate_storage(&mut t).unwrap();
 

--- a/substrate-node/pallets/pallet-tft-price/src/lib.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/lib.rs
@@ -135,6 +135,16 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1))]
+        pub fn set_allowed_origin(
+            origin: OriginFor<T>,
+            target: T::AccountId,
+        ) -> DispatchResultWithPostInfo {
+            T::RestrictedOrigin::ensure_origin(origin)?;
+            AllowedOrigin::<T>::set(Some(target));
+            Ok(().into())
+        }
+
         #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1) + T::DbWeight::get().reads(1))]
         pub fn set_prices(
             origin: OriginFor<T>,
@@ -149,16 +159,6 @@ pub mod pallet {
                 );
                 Self::calculate_and_set_price(price, block_number)?;
             }
-            Ok(().into())
-        }
-
-        #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1))]
-        pub fn set_allowed_origin(
-            origin: OriginFor<T>,
-            target: T::AccountId,
-        ) -> DispatchResultWithPostInfo {
-            T::RestrictedOrigin::ensure_origin(origin)?;
-            AllowedOrigin::<T>::set(Some(target));
             Ok(().into())
         }
 

--- a/substrate-node/pallets/pallet-tft-price/src/lib.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/lib.rs
@@ -133,6 +133,10 @@ pub mod pallet {
     #[pallet::getter(fn min_tft_price)]
     pub type MinTftPrice<T> = StorageValue<_, u32, ValueQuery>;
 
+    #[pallet::storage]
+    #[pallet::getter(fn max_tft_price)]
+    pub type MaxTftPrice<T> = StorageValue<_, u32, ValueQuery>;
+
     #[pallet::call]
     impl<T: Config> Pallet<T> {
         #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1))]
@@ -168,6 +172,13 @@ pub mod pallet {
             MinTftPrice::<T>::put(price);
             Ok(().into())
         }
+
+        #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1))]
+        pub fn set_max_tft_price(origin: OriginFor<T>, price: u32) -> DispatchResultWithPostInfo {
+            T::RestrictedOrigin::ensure_origin(origin)?;
+            MaxTftPrice::<T>::put(price);
+            Ok(().into())
+        }
     }
 
     #[pallet::hooks]
@@ -184,6 +195,7 @@ pub mod pallet {
     pub struct GenesisConfig<T: Config> {
         pub allowed_origin: Option<T::AccountId>,
         pub min_tft_price: u32,
+        pub max_tft_price: u32,
     }
 
     #[cfg(feature = "std")]
@@ -192,6 +204,7 @@ pub mod pallet {
             Self {
                 allowed_origin: None,
                 min_tft_price: 10,
+                max_tft_price: 1000,
             }
         }
     }
@@ -201,6 +214,7 @@ pub mod pallet {
         fn build(&self) {
             AllowedOrigin::<T>::set(self.allowed_origin.clone());
             MinTftPrice::<T>::put(self.min_tft_price);
+            MaxTftPrice::<T>::put(self.max_tft_price);
         }
     }
 }

--- a/substrate-node/pallets/pallet-tft-price/src/lib.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/lib.rs
@@ -146,16 +146,6 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1))]
-        pub fn set_allowed_origin(
-            origin: OriginFor<T>,
-            target: T::AccountId,
-        ) -> DispatchResultWithPostInfo {
-            T::RestrictedOrigin::ensure_origin(origin)?;
-            AllowedOrigin::<T>::set(Some(target));
-            Ok(().into())
-        }
-
         #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1) + T::DbWeight::get().reads(1))]
         pub fn set_prices(
             origin: OriginFor<T>,
@@ -170,6 +160,16 @@ pub mod pallet {
                 );
                 Self::calculate_and_set_price(price, block_number)?;
             }
+            Ok(().into())
+        }
+
+        #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1))]
+        pub fn set_allowed_origin(
+            origin: OriginFor<T>,
+            target: T::AccountId,
+        ) -> DispatchResultWithPostInfo {
+            T::RestrictedOrigin::ensure_origin(origin)?;
+            AllowedOrigin::<T>::set(Some(target));
             Ok(().into())
         }
 

--- a/substrate-node/pallets/pallet-tft-price/src/lib.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/lib.rs
@@ -191,7 +191,7 @@ pub mod pallet {
         fn default() -> Self {
             Self {
                 allowed_origin: None,
-                min_tft_price: 30,
+                min_tft_price: 10,
             }
         }
     }

--- a/substrate-node/pallets/pallet-tft-price/src/lib.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/lib.rs
@@ -26,6 +26,9 @@ const DST_CODE: &str = "TFT";
 const DST_AMOUNT: u32 = 100;
 
 #[cfg(test)]
+mod mock;
+
+#[cfg(test)]
 mod tests;
 
 // Re-export pallet items so that they can be accessed from the crate namespace.

--- a/substrate-node/pallets/pallet-tft-price/src/lib.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/lib.rs
@@ -5,7 +5,6 @@
 /// https://substrate.dev/docs/en/knowledgebase/runtime/frame
 use frame_support::{dispatch::DispatchResultWithPostInfo, weights::Pays};
 use frame_system::offchain::{SendSignedTransaction, Signer};
-use lite_json::json::JsonValue;
 use log;
 use sp_runtime::offchain::{http, Duration};
 use sp_runtime::traits::SaturatedConversion;
@@ -317,28 +316,6 @@ impl<T: Config> Pallet<T> {
         // The case of `None`: no account is available for sending
         log::error!("No local account available");
         return Err(<Error<T>>::OffchainSignedTxError);
-    }
-
-    /// Parse the price from the given JSON string using `lite-json`.
-    ///
-    /// Returns `None` when parsing failed or `Some(price in mUSD)` when parsing is successful.
-    pub fn parse_price(price_str: &str) -> Option<u32> {
-        let val = lite_json::parse_json(price_str);
-        let price = match val.ok()? {
-            JsonValue::Object(obj) => {
-                let (_, v) = obj
-                    .into_iter()
-                    .find(|(k, _)| k.iter().copied().eq("USD".chars()))?;
-                match v {
-                    JsonValue::Number(number) => number,
-                    _ => return None,
-                }
-            }
-            _ => return None,
-        };
-
-        let exp = price.fraction_length.saturating_sub(3);
-        Some(price.integer as u32 * 1000 + (price.fraction / 10_u64.pow(exp)) as u32)
     }
 
     /// Parse the lowest price from the given JSON string using `serde_json`.

--- a/substrate-node/pallets/pallet-tft-price/src/lib.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/lib.rs
@@ -98,6 +98,8 @@ pub mod pallet {
         OffchainSignedTxError,
         NoLocalAcctForSigning,
         AccountUnauthorizedToSetPrice,
+        MaxPriceLowerThanMinPriceError,
+        MinPriceHigherThanMaxPriceError,
     }
 
     #[pallet::pallet]
@@ -166,16 +168,24 @@ pub mod pallet {
             Ok(().into())
         }
 
-        #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1))]
+        #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1) + T::DbWeight::get().reads(1))]
         pub fn set_min_tft_price(origin: OriginFor<T>, price: u32) -> DispatchResultWithPostInfo {
             T::RestrictedOrigin::ensure_origin(origin)?;
+            ensure!(
+                price < MaxTftPrice::<T>::get(),
+                Error::<T>::MinPriceHigherThanMaxPriceError
+            );
             MinTftPrice::<T>::put(price);
             Ok(().into())
         }
 
-        #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1))]
+        #[pallet::weight(100_000_000 + T::DbWeight::get().writes(1) + T::DbWeight::get().reads(1))]
         pub fn set_max_tft_price(origin: OriginFor<T>, price: u32) -> DispatchResultWithPostInfo {
             T::RestrictedOrigin::ensure_origin(origin)?;
+            ensure!(
+                price > MinTftPrice::<T>::get(),
+                Error::<T>::MaxPriceLowerThanMinPriceError
+            );
             MaxTftPrice::<T>::put(price);
             Ok(().into())
         }

--- a/substrate-node/pallets/pallet-tft-price/src/mock.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/mock.rs
@@ -1,0 +1,183 @@
+#![cfg(test)]
+
+use super::*;
+use crate::{self as pallet_tft_price};
+use codec::alloc::sync::Arc;
+use frame_support::traits::GenesisBuild;
+use frame_support::{construct_runtime, parameter_types, traits::ConstU32};
+use frame_system::EnsureRoot;
+use frame_system::{limits, mocking};
+use sp_core::{
+    offchain::{testing, OffchainDbExt, TransactionPoolExt},
+    sr25519, H256,
+};
+use sp_io::TestExternalities;
+use sp_keystore::{testing::KeyStore, KeystoreExt, SyncCryptoStore};
+use sp_runtime::{
+    testing::{Header, TestXt},
+    traits::{BlakeTwo256, Extrinsic as ExtrinsicT, IdentifyAccount, IdentityLookup, Verify},
+};
+
+type Extrinsic = TestXt<Call, ()>;
+type UncheckedExtrinsic = mocking::MockUncheckedExtrinsic<TestRuntime>;
+type Block = mocking::MockBlock<TestRuntime>;
+use sp_runtime::MultiSignature;
+pub type Signature = MultiSignature;
+pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+
+// For testing the module, we construct a mock runtime.
+construct_runtime!(
+    pub enum TestRuntime where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+        TFTPriceModule: pallet_tft_price::{Pallet, Call, Storage, Config<T>, Event<T>},
+    }
+);
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub BlockWeights: limits::BlockWeights = limits::BlockWeights::simple_max(1024);
+}
+
+impl frame_system::Config for TestRuntime {
+    type BaseCallFilter = frame_support::traits::Everything;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type Origin = Origin;
+    type Index = u64;
+    type Call = Call;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type DbWeight = ();
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = ();
+    type OnSetCode = ();
+    type MaxConsumers = ConstU32<16>;
+}
+
+parameter_types! {
+    pub const UnsignedPriority: u64 = 100;
+}
+
+impl Config for TestRuntime {
+    type AuthorityId = pallet_tft_price::AuthId;
+    type Call = Call;
+    type Event = Event;
+    type RestrictedOrigin = EnsureRoot<Self::AccountId>;
+}
+
+impl frame_system::offchain::SigningTypes for TestRuntime {
+    type Public = <Signature as Verify>::Signer;
+    type Signature = Signature;
+}
+
+impl<C> frame_system::offchain::SendTransactionTypes<C> for TestRuntime
+where
+    Call: From<C>,
+{
+    type OverarchingCall = Call;
+    type Extrinsic = Extrinsic;
+}
+
+impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for TestRuntime
+where
+    Call: From<LocalCall>,
+{
+    fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
+        call: Call,
+        _public: <Signature as Verify>::Signer,
+        _account: AccountId,
+        nonce: u64,
+    ) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
+        Some((call, (nonce, ())))
+    }
+}
+
+use sp_core::{Pair, Public};
+type AccountPublic = <MultiSignature as Verify>::Signer;
+
+/// Helper function to generate a crypto pair from seed
+fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+    TPublic::Pair::from_string(&format!("//{}", seed), None)
+        .expect("static values are valid; qed")
+        .public()
+}
+
+fn get_from_seed_string<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+    TPublic::Pair::from_string(&format!("{}", seed), None)
+        .expect("static values are valid; qed")
+        .public()
+}
+
+/// Helper function to generate an account ID from seed
+fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
+where
+    AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+{
+    AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
+}
+
+fn get_account_id_from_seed_string<TPublic: Public>(seed: &str) -> AccountId
+where
+    AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+{
+    AccountPublic::from(get_from_seed_string::<TPublic>(seed)).into_account()
+}
+
+pub fn allowed_account() -> AccountId {
+    get_account_id_from_seed_string::<sr25519::Public>(
+        "expire stage crawl shell boss any story swamp skull yellow bamboo copy",
+    )
+}
+
+pub fn bob() -> AccountId {
+    get_account_id_from_seed::<sr25519::Public>("Bob")
+}
+
+pub struct ExternalityBuilder;
+
+impl ExternalityBuilder {
+    pub fn build() -> TestExternalities {
+        const PHRASE: &str =
+            "expire stage crawl shell boss any story swamp skull yellow bamboo copy";
+
+        let (offchain, _) = testing::TestOffchainExt::new();
+        let (pool, _) = testing::TestTransactionPoolExt::new();
+        let keystore = KeyStore::new();
+        keystore
+            .sr25519_generate_new(KEY_TYPE, Some(&format!("{}/hunter1", PHRASE)))
+            .unwrap();
+
+        let mut storage = frame_system::GenesisConfig::default()
+            .build_storage::<TestRuntime>()
+            .unwrap();
+
+        let genesis = pallet_tft_price::GenesisConfig::<TestRuntime> {
+            allowed_origin: Some(allowed_account()),
+            min_tft_price: 10,
+            max_tft_price: 1000,
+        };
+        genesis.assimilate_storage(&mut storage).unwrap();
+
+        let mut t = TestExternalities::from(storage);
+        t.register_extension(OffchainDbExt::new(offchain));
+        t.register_extension(TransactionPoolExt::new(pool));
+        t.register_extension(KeystoreExt(Arc::new(keystore)));
+        t.execute_with(|| System::set_block_number(1));
+        t
+    }
+}

--- a/substrate-node/pallets/pallet-tft-price/src/tests.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/tests.rs
@@ -1,189 +1,8 @@
 use super::Event as TftPriceEvent;
-use crate::{self as pallet_tft_price, *};
-use codec::alloc::sync::Arc;
-use frame_support::error::BadOrigin;
-use frame_support::traits::GenesisBuild;
-use frame_support::{assert_noop, assert_ok, construct_runtime, parameter_types, traits::ConstU32};
-use frame_system::{limits, mocking, EventRecord, Phase};
-use frame_system::{EnsureRoot, RawOrigin};
-use sp_core::{
-    offchain::{
-        testing::{self},
-        OffchainDbExt, TransactionPoolExt,
-    },
-    sr25519::{self},
-    H256,
-};
-use sp_io::TestExternalities;
-use sp_keystore::{testing::KeyStore, KeystoreExt, SyncCryptoStore};
-use sp_runtime::{
-    testing::{Header, TestXt},
-    traits::{BlakeTwo256, Extrinsic as ExtrinsicT, IdentifyAccount, IdentityLookup, Verify},
-};
-
-type Extrinsic = TestXt<Call, ()>;
-type UncheckedExtrinsic = mocking::MockUncheckedExtrinsic<TestRuntime>;
-type Block = mocking::MockBlock<TestRuntime>;
-use sp_runtime::MultiSignature;
-pub type Signature = MultiSignature;
-pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
-
-// For testing the module, we construct a mock runtime.
-construct_runtime!(
-    pub enum TestRuntime where
-        Block = Block,
-        NodeBlock = Block,
-        UncheckedExtrinsic = UncheckedExtrinsic,
-    {
-        System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-        TFTPriceModule: pallet_tft_price::{Pallet, Call, Storage, Config<T>, Event<T>},
-    }
-);
-
-parameter_types! {
-    pub const BlockHashCount: u64 = 250;
-    pub BlockWeights: limits::BlockWeights = limits::BlockWeights::simple_max(1024);
-}
-
-impl frame_system::Config for TestRuntime {
-    type BaseCallFilter = frame_support::traits::Everything;
-    type BlockWeights = ();
-    type BlockLength = ();
-    type Origin = Origin;
-    type Index = u64;
-    type Call = Call;
-    type BlockNumber = u64;
-    type Hash = H256;
-    type Hashing = BlakeTwo256;
-    type AccountId = AccountId;
-    type Lookup = IdentityLookup<Self::AccountId>;
-    type Header = Header;
-    type Event = Event;
-    type BlockHashCount = BlockHashCount;
-    type DbWeight = ();
-    type Version = ();
-    type PalletInfo = PalletInfo;
-    type AccountData = ();
-    type OnNewAccount = ();
-    type OnKilledAccount = ();
-    type SystemWeightInfo = ();
-    type SS58Prefix = ();
-    type OnSetCode = ();
-    type MaxConsumers = ConstU32<16>;
-}
-
-parameter_types! {
-    pub const UnsignedPriority: u64 = 100;
-}
-
-impl Config for TestRuntime {
-    type AuthorityId = pallet_tft_price::AuthId;
-    type Call = Call;
-    type Event = Event;
-    type RestrictedOrigin = EnsureRoot<Self::AccountId>;
-}
-
-impl frame_system::offchain::SigningTypes for TestRuntime {
-    type Public = <Signature as Verify>::Signer;
-    type Signature = Signature;
-}
-
-impl<C> frame_system::offchain::SendTransactionTypes<C> for TestRuntime
-where
-    Call: From<C>,
-{
-    type OverarchingCall = Call;
-    type Extrinsic = Extrinsic;
-}
-
-impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for TestRuntime
-where
-    Call: From<LocalCall>,
-{
-    fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
-        call: Call,
-        _public: <Signature as Verify>::Signer,
-        _account: AccountId,
-        nonce: u64,
-    ) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
-        Some((call, (nonce, ())))
-    }
-}
-
-use sp_core::{Pair, Public};
-type AccountPublic = <MultiSignature as Verify>::Signer;
-
-/// Helper function to generate a crypto pair from seed
-fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("//{}", seed), None)
-        .expect("static values are valid; qed")
-        .public()
-}
-
-fn get_from_seed_string<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("{}", seed), None)
-        .expect("static values are valid; qed")
-        .public()
-}
-
-/// Helper function to generate an account ID from seed
-fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
-where
-    AccountPublic: From<<TPublic::Pair as Pair>::Public>,
-{
-    AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
-}
-
-fn get_account_id_from_seed_string<TPublic: Public>(seed: &str) -> AccountId
-where
-    AccountPublic: From<<TPublic::Pair as Pair>::Public>,
-{
-    AccountPublic::from(get_from_seed_string::<TPublic>(seed)).into_account()
-}
-
-pub fn allowed_account() -> AccountId {
-    get_account_id_from_seed_string::<sr25519::Public>(
-        "expire stage crawl shell boss any story swamp skull yellow bamboo copy",
-    )
-}
-
-pub fn bob() -> AccountId {
-    get_account_id_from_seed::<sr25519::Public>("Bob")
-}
-
-pub struct ExternalityBuilder;
-
-impl ExternalityBuilder {
-    pub fn build() -> TestExternalities {
-        const PHRASE: &str =
-            "expire stage crawl shell boss any story swamp skull yellow bamboo copy";
-
-        let (offchain, _) = testing::TestOffchainExt::new();
-        let (pool, _) = testing::TestTransactionPoolExt::new();
-        let keystore = KeyStore::new();
-        keystore
-            .sr25519_generate_new(KEY_TYPE, Some(&format!("{}/hunter1", PHRASE)))
-            .unwrap();
-
-        let mut storage = frame_system::GenesisConfig::default()
-            .build_storage::<TestRuntime>()
-            .unwrap();
-
-        let genesis = pallet_tft_price::GenesisConfig::<TestRuntime> {
-            allowed_origin: Some(allowed_account()),
-            min_tft_price: 10,
-            max_tft_price: 1000,
-        };
-        genesis.assimilate_storage(&mut storage).unwrap();
-
-        let mut t = TestExternalities::from(storage);
-        t.register_extension(OffchainDbExt::new(offchain));
-        t.register_extension(TransactionPoolExt::new(pool));
-        t.register_extension(KeystoreExt(Arc::new(keystore)));
-        t.execute_with(|| System::set_block_number(1));
-        t
-    }
-}
+use crate::{mock::Event as MockEvent, mock::*, Error};
+use frame_support::{assert_noop, assert_ok, error::BadOrigin};
+use frame_system::{EventRecord, Phase, RawOrigin};
+use sp_core::H256;
 
 #[test]
 fn test_set_allowed_origin_works() {
@@ -253,7 +72,7 @@ fn test_set_price_below_min_price_works() {
         let our_events = System::events();
         assert_eq!(
             our_events[our_events.len() - 1],
-            record(Event::TFTPriceModule(
+            record(MockEvent::TFTPriceModule(
                 TftPriceEvent::<TestRuntime>::AveragePriceIsBelowMinPrice(
                     5,
                     TFTPriceModule::min_tft_price()
@@ -276,7 +95,7 @@ fn test_set_price_above_max_price_works() {
         let our_events = System::events();
         assert_eq!(
             our_events[our_events.len() - 1],
-            record(Event::TFTPriceModule(
+            record(MockEvent::TFTPriceModule(
                 TftPriceEvent::<TestRuntime>::AveragePriceIsAboveMaxPrice(
                     2000,
                     TFTPriceModule::max_tft_price()

--- a/substrate-node/pallets/pallet-tft-price/src/tests.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/tests.rs
@@ -170,7 +170,7 @@ impl ExternalityBuilder {
 
         let genesis = pallet_tft_price::GenesisConfig::<TestRuntime> {
             allowed_origin: Some(allowed_account()),
-            min_tft_price: 30,
+            min_tft_price: 10,
         };
         genesis.assimilate_storage(&mut storage).unwrap();
 
@@ -286,10 +286,10 @@ fn test_set_min_tft_price_works() {
     t.execute_with(|| {
         assert_ok!(TFTPriceModule::set_min_tft_price(
             RawOrigin::Root.into(),
-            10
+            20
         ));
 
-        assert_eq!(TFTPriceModule::min_tft_price(), 10);
+        assert_eq!(TFTPriceModule::min_tft_price(), 20);
     })
 }
 
@@ -298,7 +298,7 @@ fn test_set_min_tft_price_wrong_origin_fails() {
     let mut t = ExternalityBuilder::build();
     t.execute_with(|| {
         assert_noop!(
-            TFTPriceModule::set_min_tft_price(Origin::signed(bob()), 10),
+            TFTPriceModule::set_min_tft_price(Origin::signed(bob()), 20),
             BadOrigin,
         );
     })

--- a/substrate-node/pallets/pallet-tft-price/src/tests.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/tests.rs
@@ -306,6 +306,17 @@ fn test_set_min_tft_price_wrong_origin_fails() {
 }
 
 #[test]
+fn test_set_min_tft_price_too_high_fails() {
+    let mut t = ExternalityBuilder::build();
+    t.execute_with(|| {
+        assert_noop!(
+            TFTPriceModule::set_min_tft_price(RawOrigin::Root.into(), 2000),
+            Error::<TestRuntime>::MinPriceHigherThanMaxPriceError,
+        );
+    })
+}
+
+#[test]
 fn test_set_max_tft_price_works() {
     let mut t = ExternalityBuilder::build();
     t.execute_with(|| {
@@ -325,6 +336,17 @@ fn test_set_max_tft_price_wrong_origin_fails() {
         assert_noop!(
             TFTPriceModule::set_max_tft_price(Origin::signed(bob()), 2000),
             BadOrigin,
+        );
+    })
+}
+
+#[test]
+fn test_set_max_tft_price_too_low_fails() {
+    let mut t = ExternalityBuilder::build();
+    t.execute_with(|| {
+        assert_noop!(
+            TFTPriceModule::set_max_tft_price(RawOrigin::Root.into(), 5),
+            Error::<TestRuntime>::MaxPriceLowerThanMinPriceError,
         );
     })
 }

--- a/substrate-node/pallets/pallet-tft-price/src/tests.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/tests.rs
@@ -223,20 +223,6 @@ fn test_set_price_wrong_origin_fails() {
 }
 
 #[test]
-fn test_parse_price_works() {
-    let mut t = ExternalityBuilder::build();
-    t.execute_with(|| {
-        let price_str = "{\n\"USD\": 0.04457\n}";
-        let price = TFTPriceModule::parse_price(price_str).unwrap();
-        assert_eq!(price, 44);
-
-        let price_str = "{\n\"USD\": 1.14457\n}";
-        let price = TFTPriceModule::parse_price(price_str).unwrap();
-        assert_eq!(price, 1144);
-    })
-}
-
-#[test]
 fn test_parse_lowest_price_from_valid_request_works() {
     let mut t = ExternalityBuilder::build();
     t.execute_with(|| {

--- a/substrate-node/pallets/pallet-tft-price/src/tests.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/tests.rs
@@ -288,6 +288,8 @@ fn test_set_min_tft_price_works() {
             RawOrigin::Root.into(),
             10
         ));
+
+        assert_eq!(TFTPriceModule::min_tft_price(), 10);
     })
 }
 

--- a/substrate-node/pallets/pallet-tft-price/src/tests.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/tests.rs
@@ -171,6 +171,7 @@ impl ExternalityBuilder {
         let genesis = pallet_tft_price::GenesisConfig::<TestRuntime> {
             allowed_origin: Some(allowed_account()),
             min_tft_price: 10,
+            max_tft_price: 1000,
         };
         genesis.assimilate_storage(&mut storage).unwrap();
 
@@ -299,6 +300,30 @@ fn test_set_min_tft_price_wrong_origin_fails() {
     t.execute_with(|| {
         assert_noop!(
             TFTPriceModule::set_min_tft_price(Origin::signed(bob()), 20),
+            BadOrigin,
+        );
+    })
+}
+
+#[test]
+fn test_set_max_tft_price_works() {
+    let mut t = ExternalityBuilder::build();
+    t.execute_with(|| {
+        assert_ok!(TFTPriceModule::set_max_tft_price(
+            RawOrigin::Root.into(),
+            2000
+        ));
+
+        assert_eq!(TFTPriceModule::max_tft_price(), 2000);
+    })
+}
+
+#[test]
+fn test_set_max_tft_price_wrong_origin_fails() {
+    let mut t = ExternalityBuilder::build();
+    t.execute_with(|| {
+        assert_noop!(
+            TFTPriceModule::set_max_tft_price(Origin::signed(bob()), 2000),
             BadOrigin,
         );
     })

--- a/substrate-node/pallets/pallet-tft-price/src/tests.rs
+++ b/substrate-node/pallets/pallet-tft-price/src/tests.rs
@@ -184,6 +184,30 @@ impl ExternalityBuilder {
 }
 
 #[test]
+fn test_set_allowed_origin_works() {
+    let mut t = ExternalityBuilder::build();
+    t.execute_with(|| {
+        assert_ok!(TFTPriceModule::set_allowed_origin(
+            RawOrigin::Root.into(),
+            bob(),
+        ));
+
+        assert_eq!(TFTPriceModule::allowed_origin(), Some(bob()));
+    })
+}
+
+#[test]
+fn test_set_allowed_origin_by_wrong_origin_fails() {
+    let mut t = ExternalityBuilder::build();
+    t.execute_with(|| {
+        assert_noop!(
+            TFTPriceModule::set_allowed_origin(Origin::signed(bob()), bob()),
+            BadOrigin,
+        );
+    })
+}
+
+#[test]
 fn test_set_prices_works() {
     let mut t = ExternalityBuilder::build();
     t.execute_with(|| {


### PR DESCRIPTION
Also adds a min tft price storage map. We can use this in smart contract layer to check if the avg price is lower, if so, use the min price

related to:
- #425 
- #423