### PR TITLE
fix: update node

### DIFF
--- a/substrate-node/pallets/pallet-tfgrid/src/lib.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/lib.rs
@@ -1048,7 +1048,7 @@ pub mod pallet {
             if old_node.farm_id != farm_id {
                 let mut old_nodes_by_farm = NodesByFarmID::<T>::get(old_node.farm_id);
                 old_nodes_by_farm.retain(|&id| id != node_id);
-                NodesByFarmID::<T>::insert(farm_id, old_nodes_by_farm);
+                NodesByFarmID::<T>::insert(old_node.farm_id, old_nodes_by_farm);
 
                 let mut nodes_by_farm = NodesByFarmID::<T>::get(farm_id);
                 nodes_by_farm.push(node_id);


### PR DESCRIPTION
When node is booted in other farm than initially booted in, the storage map of nodes by farm id should be properly updated.