### PR TITLE
feat: fixed both unit tests #457

### DIFF
--- a/substrate-node/pallets/pallet-dao/src/lib.rs
+++ b/substrate-node/pallets/pallet-dao/src/lib.rs
@@ -212,6 +212,16 @@ pub mod pallet {
                 Error::<T>::DuplicateProposal
             );
 
+            let now = frame_system::Pallet::<T>::block_number();
+            let mut end = now + T::MotionDuration::get();
+            if let Some(motion_duration) = duration {
+                ensure!(
+                    motion_duration < T::BlockNumber::from(constants::time::DAYS * 30),
+                    Error::<T>::InvalidProposalDuration
+                );
+                end = now + motion_duration;
+            }
+
             let index = Self::proposal_count();
             <ProposalCount<T>>::mutate(|i| *i += 1);
             <ProposalOf<T>>::insert(proposal_hash, *action);
@@ -222,16 +232,6 @@ pub mod pallet {
                 link,
             };
             <Proposals<T>>::insert(proposal_hash, p);
-
-            let now = frame_system::Pallet::<T>::block_number();
-            let mut end = now + T::MotionDuration::get();
-            if let Some(motion_duration) = duration {
-                ensure!(
-                    motion_duration < T::BlockNumber::from(constants::time::DAYS * 30),
-                    Error::<T>::InvalidProposalDuration
-                );
-                end = now + motion_duration;
-            }
 
             let votes = {
                 proposal::DaoVotes {

--- a/substrate-node/runtime/src/constants.rs
+++ b/substrate-node/runtime/src/constants.rs
@@ -86,7 +86,7 @@ pub mod fee {
 
 #[cfg(test)]
 mod tests {
-    use super::currency::{CENTS, DOLLARS, MILLICENTS};
+    use super::currency::{CENTS, MILLICENTS};
     use super::fee::WeightToFeeStruct;
     use crate::MaximumBlockWeight;
     use frame_support::weights::constants::ExtrinsicBaseWeight;
@@ -95,10 +95,10 @@ mod tests {
     #[test]
     // This function tests that the fee for `MaximumBlockWeight` of weight is correct
     fn full_block_fee_is_correct() {
-        // A full block should cost 16 DOLLARS
-        println!("Base: {}", ExtrinsicBaseWeight::get());
+        // A full block should cost 23.3112 DOLLARS
+        log::info!("MaxBlockWeight: {:?}", MaximumBlockWeight::get());
         let x = WeightToFeeStruct::weight_to_fee(&MaximumBlockWeight::get());
-        let y = 16 * DOLLARS;
+        let y = 2331120 * MILLICENTS;
         assert!(x.max(y) - x.min(y) < MILLICENTS);
     }
 
@@ -106,7 +106,7 @@ mod tests {
     // This function tests that the fee for `ExtrinsicBaseWeight` of weight is correct
     fn extrinsic_base_fee_is_correct() {
         // `ExtrinsicBaseWeight` should cost 1/10 of a CENT
-        println!("Base: {}", ExtrinsicBaseWeight::get());
+        log::info!("Base: {}", ExtrinsicBaseWeight::get());
         let x = WeightToFeeStruct::weight_to_fee(&ExtrinsicBaseWeight::get());
         let y = CENTS / 10;
         assert!(x.max(y) - x.min(y) < MILLICENTS);


### PR DESCRIPTION
Both unit tests have been fixed. The reason for the failures:

**Failure 1**
assert_noop requires the state to be unchanged when there is a failure. The code was checking the input of the API call after changing the state. Thus it could modify the state before throwing an exception. 

**Failure 2**
I believe the calculation of the price for a full block is wrong. It should not be 16 dollars but instead 23.3112 dollars:
FEE_BLOCK = MAX_AMT_EXTRINSICS_PER_BLOCK * FEE_PER_EXTRINSIC
=> MAX_AMT_EXTRINSICS_PER_BLOCK = MAX_WEIGHT_PER_BLOCK/WEIGHT_PER_EXTRINSIC
=> MAX_AMT_EXTRINSICS_PER_BLOCK ≃ 23311.38
=> FEE_PER_EXTRINSIC = 1/10 cents
FEE_BLOCK ≃ 2331.138 cents = 23.31138 dollar