### PR TITLE
chore: set bridge retry interval to 100 blocks

### DIFF
--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -374,7 +374,7 @@ parameter_types! {
     pub BillingFrequency: u64 = 600;
     pub GracePeriod: u64 = (14 * DAYS).into();
     pub DistributionFrequency: u16 = 24;
-    pub RetryInterval: u32 = 20;
+    pub RetryInterval: u32 = 100;
     pub MaxNameContractNameLength: u32 = 64;
     pub MaxNodeContractPublicIPs: u32 = 1;
     pub MaxDeploymentDataLength: u32 = 512;


### PR DESCRIPTION
To may retries are happening on devnet at the same time making the bridge not able to execute them all properly in time, setting it the withdraw interval to 100 blocks might solve the issue.