### PR TITLE
feat: rework contract billing storage

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -46,4 +46,8 @@ jobs:
           python3.10 -m pip install robotframework cryptography substrate-interface
           cd substrate-node/tests
           robot -d _output_tests/ .
+        - uses: actions/upload-artifact@v3
+          with:
+            name: integration test output
+            path: substrate-node/tests/_output_tests/
 

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -42,7 +42,7 @@ jobs:
           $HOME/.cargo/bin/cargo +nightly-2022-05-11 test --no-fail-fast
 
       - name: Integration tests
-        run: |
+        - run: |
           python3.10 -m pip install robotframework cryptography substrate-interface
           cd substrate-node/tests
           robot -d _output_tests/ .

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -48,7 +48,7 @@ jobs:
           robot -d _output_tests/ .
 
       - uses: actions/upload-artifact@v3
-        if: failure()
+        if: always()
         with:
           name: integration test output
           path: substrate-node/tests/_output_tests/

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -48,6 +48,7 @@ jobs:
           robot -d _output_tests/ .
 
       - uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: integration test output
           path: substrate-node/tests/_output_tests/

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -42,12 +42,13 @@ jobs:
           $HOME/.cargo/bin/cargo +nightly-2022-05-11 test --no-fail-fast
 
       - name: Integration tests
-        - run: |
+        run: |
           python3.10 -m pip install robotframework cryptography substrate-interface
           cd substrate-node/tests
           robot -d _output_tests/ .
-        - uses: actions/upload-artifact@v3
-          with:
-            name: integration test output
-            path: substrate-node/tests/_output_tests/
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: integration test output
+          path: substrate-node/tests/_output_tests/
 

--- a/substrate-node/pallets/pallet-smart-contract/src/lib.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/lib.rs
@@ -933,8 +933,7 @@ impl<T: Config> Pallet<T> {
         if !Contracts::<T>::contains_key(contract_id) {
             log::debug!("cleaning up deleted contract from storage");
 
-            let now = <frame_system::Pallet<T>>::block_number().saturated_into::<u64>();
-            let index = now % BillingFrequency::<T>::get();
+            let index = Self::get_contract_index();
 
             // Remove contract from billing list
             let mut contracts = ContractsToBillAt::<T>::get(index);
@@ -1450,9 +1449,8 @@ impl<T: Config> Pallet<T> {
             return;
         }
 
-        let now = <frame_system::Pallet<T>>::block_number().saturated_into::<u64>() - 1;
         // Save the contract to be billed in (now -1 %(mod) BILLING_FREQUENCY_IN_BLOCKS)
-        let index = now % BillingFrequency::<T>::get();
+        let index = Self::get_contract_index() - 1;
         let mut contracts = ContractsToBillAt::<T>::get(index);
 
         if !contracts.contains(&contract_id) {
@@ -1739,6 +1737,11 @@ impl<T: Config> Pallet<T> {
             }
         }
         Ok(().into())
+    }
+
+    pub fn get_contract_index() -> u64 {
+        let now = <frame_system::Pallet<T>>::block_number().saturated_into::<u64>();
+        now % BillingFrequency::<T>::get()
     }
 }
 

--- a/substrate-node/pallets/pallet-smart-contract/src/lib.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/lib.rs
@@ -77,6 +77,7 @@ pub mod crypto {
 pub mod weights;
 
 pub mod cost;
+pub mod migration;
 pub mod name_contract;
 pub mod types;
 

--- a/substrate-node/pallets/pallet-smart-contract/src/lib.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/lib.rs
@@ -971,9 +971,6 @@ impl<T: Config> Pallet<T> {
                 Self::remove_contract(contract.contract_id);
                 return Ok(().into());
             }
-
-            // // Reinsert into the next billing frequency
-            // Self::insert_contract_to_bill(contract.contract_id);
         }
 
         Ok(().into())
@@ -1022,17 +1019,12 @@ impl<T: Config> Pallet<T> {
         // Calculate amount of seconds elapsed based on the contract lock struct
 
         let now = <timestamp::Pallet<T>>::get().saturated_into::<u64>() / 1000;
-        log::debug!("now timestamp: {:?}", now);
         // this will set the seconds elapsed to the default billing cycle duration in seconds
         // if there is no contract lock object yet. A contract lock object will be created later in this function
         // https://github.com/threefoldtech/tfchain/issues/261
         let contract_lock = ContractLock::<T>::get(contract.contract_id);
-        log::debug!("contract lock: {:?}", contract_lock);
-        let now_block = <frame_system::Pallet<T>>::block_number().saturated_into::<u64>();
-        log::debug!("current block: {:?}", now_block);
         if contract_lock.lock_updated != 0 {
             seconds_elapsed = now.checked_sub(contract_lock.lock_updated).unwrap_or(0);
-            log::debug!("seconds elapsed: {:?}", seconds_elapsed);
         }
 
         let (amount_due, discount_received) =

--- a/substrate-node/pallets/pallet-smart-contract/src/lib.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/lib.rs
@@ -502,7 +502,11 @@ pub mod pallet {
 
             let contracts = ContractsToBillAt::<T>::get(current_index);
             if contracts.is_empty() {
-                log::debug!("No contracts to bill at block {:?}", block_number);
+                log::info!(
+                    "No contracts to bill at block {:?}, index: {:?}",
+                    block_number,
+                    current_index
+                );
                 return;
             }
 

--- a/substrate-node/pallets/pallet-smart-contract/src/migration.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/migration.rs
@@ -39,7 +39,7 @@ pub mod v5 {
 }
 
 pub fn migrate_to_version_6<T: Config>() -> frame_support::weights::Weight {
-    if PalletVersion::<T>::get() == types::StorageVersion::V6 {
+    if PalletVersion::<T>::get() == types::StorageVersion::V5 {
         info!(
             " >>> Starting contract pallet migration, pallet version: {:?}",
             PalletVersion::<T>::get()
@@ -57,12 +57,17 @@ pub fn migrate_to_version_6<T: Config>() -> frame_support::weights::Weight {
             b"",
         );
 
-        let billing_frequency = BillingFrequency::<T>::get();
+        let billing_frequency = DefaultBillingFrequency::<T>::get();
         for (block_number, contract_ids) in contracts_to_bill_at {
             migrated_count += 1;
             // Construct new index
-            let index = block_number - 1 % billing_frequency;
+            let index = (block_number - 1) % billing_frequency;
             // Reinsert items under the new key
+            info!(
+                "inserted contracts:{:?} at index: {:?}",
+                contract_ids.clone(),
+                index
+            );
             ContractsToBillAt::<T>::insert(index, contract_ids);
         }
 

--- a/substrate-node/pallets/pallet-smart-contract/src/migration.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/migration.rs
@@ -1,0 +1,84 @@
+use super::*;
+use frame_support::weights::Weight;
+
+pub mod v5 {
+    use super::*;
+    use crate::Config;
+
+    use frame_support::{pallet_prelude::Weight, traits::OnRuntimeUpgrade};
+    use sp_std::marker::PhantomData;
+    pub struct ContractMigrationV5<T: Config>(PhantomData<T>);
+
+    impl<T: Config> OnRuntimeUpgrade for ContractMigrationV5<T> {
+        #[cfg(feature = "try-runtime")]
+        fn pre_upgrade() -> Result<(), &'static str> {
+            info!("current pallet version: {:?}", PalletVersion::<T>::get());
+            assert!(PalletVersion::<T>::get() == types::StorageVersion::V5);
+
+            info!("👥  Smart Contract pallet to v6 passes PRE migrate checks ✅",);
+            Ok(())
+        }
+
+        fn on_runtime_upgrade() -> Weight {
+            migrate_to_version_6::<T>()
+        }
+
+        #[cfg(feature = "try-runtime")]
+        fn post_upgrade() -> Result<(), &'static str> {
+            info!("current pallet version: {:?}", PalletVersion::<T>::get());
+            assert!(PalletVersion::<T>::get() == types::StorageVersion::V6);
+
+            info!(
+                "👥  Smart Contract pallet to {:?} passes POST migrate checks ✅",
+                PalletVersion::<T>::get()
+            );
+
+            Ok(())
+        }
+    }
+}
+
+pub fn migrate_to_version_6<T: Config>() -> frame_support::weights::Weight {
+    if PalletVersion::<T>::get() == types::StorageVersion::V6 {
+        info!(
+            " >>> Starting contract pallet migration, pallet version: {:?}",
+            PalletVersion::<T>::get()
+        );
+
+        let mut migrated_count = 0;
+
+        // Collect ContractsToBillAt storage in memory
+        let contracts_to_bill_at = ContractsToBillAt::<T>::iter().collect::<Vec<_>>();
+
+        // Remove all items under ContractsToBillAt
+        frame_support::migration::remove_storage_prefix(
+            b"SmartContractModule",
+            b"ContractsToBillAt",
+            b"",
+        );
+
+        let billing_frequency = BillingFrequency::<T>::get();
+        for (block_number, contract_ids) in contracts_to_bill_at {
+            migrated_count += 1;
+            // Construct new index
+            let index = block_number - 1 % billing_frequency;
+            // Reinsert items under the new key
+            ContractsToBillAt::<T>::insert(index, contract_ids);
+        }
+
+        info!(
+            " <<< Contracts storage updated! Migrated {} Contracts ✅",
+            migrated_count
+        );
+
+        // Update pallet storage version
+        PalletVersion::<T>::set(types::StorageVersion::V6);
+        info!(" <<< Storage version upgraded");
+
+        // Return the weight consumed by the migration.
+        T::DbWeight::get().reads_writes(migrated_count as Weight + 1, migrated_count as Weight + 1)
+    } else {
+        info!(" >>> Unused migration");
+        return 0;
+    }
+}

--- a/substrate-node/pallets/pallet-smart-contract/src/migration.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/migration.rs
@@ -57,11 +57,13 @@ pub fn migrate_to_version_6<T: Config>() -> frame_support::weights::Weight {
             b"",
         );
 
-        let billing_frequency = DefaultBillingFrequency::<T>::get();
+        let billing_freq = 600;
+        BillingFrequency::<T>::put(billing_freq);
+
         for (block_number, contract_ids) in contracts_to_bill_at {
             migrated_count += 1;
             // Construct new index
-            let index = (block_number - 1) % billing_frequency;
+            let index = (block_number - 1) % billing_freq;
             // Reinsert items under the new key
             info!(
                 "inserted contracts:{:?} at index: {:?}",

--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -356,10 +356,6 @@ impl PoolState {
         ));
     }
 
-    // fn should_call(&mut self, expected_call: TransactionCall, expected_result: ExtrinsicResult) {
-    //     self.expected_calls.push((expected_call, expected_result));
-    // }
-
     pub fn execute_calls_and_check_results(&mut self) {
         if self.calls_to_execute.len() == 0 {
             return;

--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -343,17 +343,9 @@ pub struct PoolState {
 }
 
 impl PoolState {
-    pub fn should_call_bill_contract(
-        &mut self,
-        contract_id: u64,
-        block_number: BlockNumber,
-        expected_result: Result<(), ()>,
-    ) {
+    pub fn should_call_bill_contract(&mut self, contract_id: u64, expected_result: Result<(), ()>) {
         self.expected_calls.push((
-            crate::Call::bill_contract_for_block {
-                contract_id,
-                block_number,
-            },
+            crate::Call::bill_contract_for_block { contract_id },
             expected_result,
         ));
     }
@@ -366,29 +358,24 @@ impl PoolState {
         if self.calls_to_execute.len() == 0 {
             return;
         }
-    
+
         // execute the calls that were submitted to the pool and compare the result
         for call_to_execute in self.calls_to_execute.iter() {
             let result = match call_to_execute.0 {
                 // matches bill_contract_for_block
-                crate::Call::bill_contract_for_block {
-                    contract_id,
-                    block_number,
-                } => SmartContractModule::bill_contract_for_block(
-                    Origin::signed(bob()),
-                    contract_id,
-                    block_number,
-                ),
+                crate::Call::bill_contract_for_block { contract_id } => {
+                    SmartContractModule::bill_contract_for_block(Origin::signed(bob()), contract_id)
+                }
                 // did not match anything => unkown call => this means you should add
                 // a capture for that function here
                 _ => panic!("Unknown call!"),
             };
-    
+
             let result = match result {
                 Ok(_) => Ok(()),
                 Err(_) => Err(()),
             };
-    
+
             // the call should return what we expect it to return
             assert_eq!(
                 call_to_execute.1, result,
@@ -396,7 +383,7 @@ impl PoolState {
                 call_to_execute.0
             );
         }
-    
+
         self.calls_to_execute.clear();
     }
 }
@@ -411,10 +398,10 @@ impl Drop for PoolState {
 }
 
 /// Implementation of mocked transaction pool used for testing
-/// 
-/// This transaction pool mocks submitting the transactions to the pool. It does 
+///
+/// This transaction pool mocks submitting the transactions to the pool. It does
 /// not execute the transactions. Instead it keeps them in list. It does compare
-/// the submitted call to the expected call. 
+/// the submitted call to the expected call.
 #[derive(Default)]
 pub struct MockedTransactionPoolExt(Arc<RwLock<PoolState>>);
 

--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -339,8 +339,8 @@ pub type ExtrinsicResult = Result<PostDispatchInfo, DispatchErrorWithPostInfo>;
 #[derive(Default)]
 pub struct PoolState {
     /// A vector of calls that we expect should be executed
-    pub expected_calls: Vec<(TransactionCall, ExtrinsicResult)>,
-    pub calls_to_execute: Vec<(TransactionCall, ExtrinsicResult)>,
+    pub expected_calls: Vec<(TransactionCall, ExtrinsicResult, u64)>,
+    pub calls_to_execute: Vec<(TransactionCall, ExtrinsicResult, u64)>,
     pub i: usize,
 }
 
@@ -349,14 +349,16 @@ impl PoolState {
         &mut self,
         contract_id: u64,
         expected_result: ExtrinsicResult,
+        block_number: u64,
     ) {
         self.expected_calls.push((
             crate::Call::bill_contract_for_block { contract_id },
             expected_result,
+            block_number,
         ));
     }
 
-    pub fn execute_calls_and_check_results(&mut self) {
+    pub fn execute_calls_and_check_results(&mut self, block_number: u64) {
         if self.calls_to_execute.len() == 0 {
             return;
         }
@@ -379,6 +381,8 @@ impl PoolState {
                 "The result of call to {:?} was not as expected!",
                 call_to_execute.0
             );
+
+            assert_eq!(block_number, call_to_execute.2);
         }
 
         self.calls_to_execute.clear();

--- a/substrate-node/pallets/pallet-smart-contract/src/test_utils.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/test_utils.rs
@@ -17,7 +17,7 @@ pub fn run_to_block(n: u64, pool_state: Option<&mut Arc<RwLock<PoolState>>>) {
                 .as_ref()
                 .unwrap()
                 .write()
-                .execute_calls_and_check_results();
+                .execute_calls_and_check_results(System::block_number() as u64);
         }
         System::set_block_number(System::block_number() + 1);
         System::on_initialize(System::block_number());

--- a/substrate-node/pallets/pallet-smart-contract/src/test_utils.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/test_utils.rs
@@ -1,6 +1,5 @@
 #![cfg(test)]
 
-
 use crate::mock::{PoolState, SmartContractModule, System, Timestamp};
 
 use codec::alloc::sync::Arc;
@@ -9,12 +8,16 @@ use parking_lot::RwLock;
 
 pub fn run_to_block(n: u64, pool_state: Option<&mut Arc<RwLock<PoolState>>>) {
     Timestamp::set_timestamp((1628082000 * 1000) + (6000 * n));
-    while System::block_number() < n {
+    while System::block_number() <= n {
         SmartContractModule::offchain_worker(System::block_number());
         SmartContractModule::on_finalize(System::block_number());
         System::on_finalize(System::block_number());
         if pool_state.is_some() {
-            pool_state.as_ref().unwrap().write().execute_calls_and_check_results();
+            pool_state
+                .as_ref()
+                .unwrap()
+                .write()
+                .execute_calls_and_check_results();
         }
         System::set_block_number(System::block_number() + 1);
         System::on_initialize(System::block_number());

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -748,7 +748,7 @@ fn test_node_contract_billing_details() {
 
         push_nru_report_for_contract(1, 10);
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(0);
+        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(1);
         assert_eq!(contract_to_bill, [1]);
 
         let initial_total_issuance = Balances::total_issuance();
@@ -836,7 +836,7 @@ fn test_node_contract_billing_details_with_solution_provider() {
 
         push_nru_report_for_contract(1, 10);
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(0);
+        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(1);
         assert_eq!(contract_to_bill, [1]);
 
         // advance 25 cycles
@@ -879,7 +879,7 @@ fn test_multiple_contracts_billing_loop_works() {
             "some_name".as_bytes().to_vec(),
         ));
 
-        let contracts_to_bill_at_block = SmartContractModule::contract_to_bill_at_block(0);
+        let contracts_to_bill_at_block = SmartContractModule::contract_to_bill_at_block(1);
         assert_eq!(contracts_to_bill_at_block.len(), 2);
 
         // 2 contracts => 2 billings
@@ -1141,26 +1141,26 @@ fn test_node_contract_only_public_ip_billing_cycles() {
                 .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()));
         }
 
-        let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 11);
+        let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
         assert_ne!(amount_due_as_u128, 0);
-        run_to_block(12, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 12, discount_received);
+        run_to_block(11, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 11, discount_received);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
-        run_to_block(22, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 22, discount_received);
+        run_to_block(21, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 21, discount_received);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
-        run_to_block(32, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 32, discount_received);
+        run_to_block(31, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 31, discount_received);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
-        run_to_block(42, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 42, discount_received);
+        run_to_block(41, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 41, discount_received);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
-        run_to_block(52, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 52, discount_received);
+        run_to_block(51, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 51, discount_received);
     });
 }
 
@@ -1192,16 +1192,16 @@ fn test_node_contract_billing_cycles_cancel_contract_during_cycle_works() {
         }
         push_contract_resources_used(1);
 
-        let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 11);
-        run_to_block(12, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 12, discount_received);
+        let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
+        run_to_block(11, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 11, discount_received);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
-        run_to_block(22, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 22, discount_received);
+        run_to_block(21, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 21, discount_received);
 
         run_to_block(28, Some(&mut pool_state));
-        let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 6);
+        let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 7);
         assert_ok!(SmartContractModule::cancel_contract(
             Origin::signed(bob()),
             1
@@ -1235,7 +1235,7 @@ fn test_node_contract_billing_fails() {
             None
         ));
 
-        let contracts_to_bill_at_block = SmartContractModule::contract_to_bill_at_block(0);
+        let contracts_to_bill_at_block = SmartContractModule::contract_to_bill_at_block(1);
         assert_eq!(contracts_to_bill_at_block.len(), 1);
 
         let contract_id = contracts_to_bill_at_block[0];
@@ -1360,17 +1360,17 @@ fn test_node_contract_out_of_funds_should_move_state_to_graceperiod_works() {
         pool_state
             .write()
             .should_call_bill_contract(1, Ok(Pays::Yes.into()));
-        run_to_block(12, Some(&mut pool_state));
+        run_to_block(11, Some(&mut pool_state));
 
         // cycle 2
         // user does not have enough funds to pay for 2 cycles
         pool_state
             .write()
             .should_call_bill_contract(1, Ok(Pays::Yes.into()));
-        run_to_block(22, Some(&mut pool_state));
+        run_to_block(21, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(20));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(21));
 
         let our_events = System::events();
         assert_eq!(
@@ -1379,7 +1379,7 @@ fn test_node_contract_out_of_funds_should_move_state_to_graceperiod_works() {
                     contract_id: 1,
                     node_id: 1,
                     twin_id: 3,
-                    block_number: 20
+                    block_number: 21
                 }
             ))),
             true
@@ -1412,14 +1412,14 @@ fn test_restore_node_contract_in_grace_works() {
         push_contract_resources_used(1);
 
         // cycle 1
-        run_to_block(12, Some(&mut pool_state));
+        run_to_block(11, Some(&mut pool_state));
 
         // cycle 2
         // user does not have enough funds to pay for 2 cycles
-        run_to_block(22, Some(&mut pool_state));
+        run_to_block(21, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(20));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(21));
 
         let our_events = System::events();
         assert_eq!(
@@ -1428,14 +1428,14 @@ fn test_restore_node_contract_in_grace_works() {
                     contract_id: 1,
                     node_id: 1,
                     twin_id: 3,
-                    block_number: 20
+                    block_number: 21
                 }
             ))),
             true
         );
 
-        run_to_block(32, Some(&mut pool_state));
-        run_to_block(42, Some(&mut pool_state));
+        run_to_block(31, Some(&mut pool_state));
+        run_to_block(41, Some(&mut pool_state));
         // Transfer some balance to the owner of the contract to trigger the grace period to stop
         Balances::transfer(Origin::signed(bob()), charlie(), 100000000).unwrap();
         run_to_block(52, Some(&mut pool_state));
@@ -1469,17 +1469,17 @@ fn test_node_contract_grace_period_cancels_contract_when_grace_period_ends_works
         pool_state
             .write()
             .should_call_bill_contract(1, Ok(Pays::Yes.into()));
-        run_to_block(12, Some(&mut pool_state));
+        run_to_block(11, Some(&mut pool_state));
 
         // cycle 2
         // user does not have enough funds to pay for 2 cycles
         pool_state
             .write()
             .should_call_bill_contract(1, Ok(Pays::Yes.into()));
-        run_to_block(22, Some(&mut pool_state));
+        run_to_block(21, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(20));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(21));
 
         let our_events = System::events();
         assert_eq!(
@@ -1488,21 +1488,27 @@ fn test_node_contract_grace_period_cancels_contract_when_grace_period_ends_works
                     contract_id: 1,
                     node_id: 1,
                     twin_id: 3,
-                    block_number: 20
+                    block_number: 21
                 }
             ))),
             true
         );
 
         // grace period stops after 100 blocknumbers, so after 121
-        for _ in 0..11 {
+        for _ in 1..10 {
             pool_state
                 .write()
                 .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         }
-        for i in 0..11 {
-            run_to_block(32 + i * 10, Some(&mut pool_state));
+
+        for i in 1..10 {
+            run_to_block(21 + i * 10, Some(&mut pool_state));
         }
+
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        run_to_block(121, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1);
         assert_eq!(c1, None);
@@ -1522,7 +1528,7 @@ fn test_name_contract_billing() {
             "foobar".as_bytes().to_vec()
         ));
 
-        let contracts_to_bill = SmartContractModule::contract_to_bill_at_block(0);
+        let contracts_to_bill = SmartContractModule::contract_to_bill_at_block(1);
         assert_eq!(contracts_to_bill, [1]);
 
         // let mature 11 blocks
@@ -1800,7 +1806,11 @@ fn test_rent_contract_canceled_due_to_out_of_funds_should_cancel_node_contracts_
         // Event 18: Node contract canceled
         // Event 19: Rent contract Canceled
         // => no Node Contract billed event
-        assert_eq!(our_events.len(), 20);
+        assert_eq!(our_events.len(), 10);
+
+        for e in our_events.clone().iter() {
+            info!("event: {:?}", e);
+        }
 
         assert_eq!(
             our_events[5],
@@ -1810,7 +1820,7 @@ fn test_rent_contract_canceled_due_to_out_of_funds_should_cancel_node_contracts_
                 contract_id: 1,
                 node_id: 1,
                 twin_id: 3,
-                block_number: 10
+                block_number: 11
             }))
         );
         assert_eq!(
@@ -1821,12 +1831,12 @@ fn test_rent_contract_canceled_due_to_out_of_funds_should_cancel_node_contracts_
                 contract_id: 2,
                 node_id: 1,
                 twin_id: 3,
-                block_number: 10
+                block_number: 11
             }))
         );
 
         assert_eq!(
-            our_events[18],
+            our_events[8],
             record(MockEvent::SmartContractModule(SmartContractEvent::<
                 TestRuntime,
             >::NodeContractCanceled {
@@ -1836,7 +1846,7 @@ fn test_rent_contract_canceled_due_to_out_of_funds_should_cancel_node_contracts_
             }))
         );
         assert_eq!(
-            our_events[19],
+            our_events[9],
             record(MockEvent::SmartContractModule(SmartContractEvent::<
                 TestRuntime,
             >::RentContractCanceled {
@@ -1919,10 +1929,10 @@ fn test_rent_contract_out_of_funds_should_move_state_to_graceperiod_works() {
         pool_state
             .write()
             .should_call_bill_contract(1, Ok(Pays::Yes.into()));
-        run_to_block(12, Some(&mut pool_state));
+        run_to_block(11, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(10));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(11));
 
         let our_events = System::events();
         assert_eq!(
@@ -1931,7 +1941,7 @@ fn test_rent_contract_out_of_funds_should_move_state_to_graceperiod_works() {
                     contract_id: 1,
                     node_id: 1,
                     twin_id: 3,
-                    block_number: 10
+                    block_number: 11
                 }
             ))),
             true
@@ -1961,7 +1971,7 @@ fn test_restore_rent_contract_in_grace_works() {
         run_to_block(11, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(10));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(11));
 
         let our_events = System::events();
         assert_eq!(
@@ -1972,7 +1982,7 @@ fn test_restore_rent_contract_in_grace_works() {
                 contract_id: 1,
                 node_id: 1,
                 twin_id: 3,
-                block_number: 10
+                block_number: 11
             }))
         );
 
@@ -2035,10 +2045,10 @@ fn test_restore_rent_contract_and_node_contracts_in_grace_works() {
         pool_state
             .write()
             .should_call_bill_contract(2, Ok(Pays::Yes.into()));
-        run_to_block(12, Some(&mut pool_state));
+        run_to_block(11, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(10));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(11));
 
         let our_events = System::events();
         assert_eq!(
@@ -2049,7 +2059,7 @@ fn test_restore_rent_contract_and_node_contracts_in_grace_works() {
                 contract_id: 1,
                 node_id: 1,
                 twin_id: 3,
-                block_number: 10
+                block_number: 11
             }))
         );
         assert_eq!(
@@ -2060,7 +2070,7 @@ fn test_restore_rent_contract_and_node_contracts_in_grace_works() {
                 contract_id: 2,
                 node_id: 1,
                 twin_id: 3,
-                block_number: 10
+                block_number: 11
             }))
         );
 
@@ -2103,8 +2113,9 @@ fn test_restore_rent_contract_and_node_contracts_in_grace_works() {
         assert_eq!(c1.state, types::ContractState::Created);
 
         let our_events = System::events();
+
         assert_eq!(
-            our_events[11],
+            our_events[8],
             record(MockEvent::SmartContractModule(SmartContractEvent::<
                 TestRuntime,
             >::ContractGracePeriodEnded {
@@ -2114,7 +2125,7 @@ fn test_restore_rent_contract_and_node_contracts_in_grace_works() {
             }))
         );
         assert_eq!(
-            our_events[12],
+            our_events[9],
             record(MockEvent::SmartContractModule(SmartContractEvent::<
                 TestRuntime,
             >::ContractGracePeriodEnded {
@@ -2148,7 +2159,7 @@ fn test_rent_contract_grace_period_cancels_contract_when_grace_period_ends_works
         run_to_block(12, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(10));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(11));
 
         let our_events = System::events();
         assert_eq!(
@@ -2157,7 +2168,7 @@ fn test_rent_contract_grace_period_cancels_contract_when_grace_period_ends_works
                     contract_id: 1,
                     node_id: 1,
                     twin_id: 3,
-                    block_number: 10
+                    block_number: 11
                 }
             ))),
             true

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -4,6 +4,7 @@ use crate::{mock::Event as MockEvent, mock::*, test_utils::*, Error};
 use frame_support::{
     assert_noop, assert_ok, bounded_vec,
     traits::{LockableCurrency, WithdrawReasons},
+    weights::Pays,
     BoundedVec,
 };
 use frame_system::{EventRecord, Phase, RawOrigin};
@@ -24,6 +25,7 @@ const GIGABYTE: u64 = 1024 * 1024 * 1024;
 #[test]
 fn test_create_node_contract_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_node_contract(
@@ -40,6 +42,7 @@ fn test_create_node_contract_works() {
 #[test]
 fn test_create_node_contract_with_public_ips_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_node_contract(
@@ -76,6 +79,7 @@ fn test_create_node_contract_with_public_ips_works() {
 #[test]
 fn test_create_node_contract_with_undefined_node_fails() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_noop!(
@@ -95,6 +99,7 @@ fn test_create_node_contract_with_undefined_node_fails() {
 #[test]
 fn test_create_node_contract_with_same_hash_and_node_fails() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         let h = generate_deployment_hash();
@@ -124,6 +129,7 @@ fn test_create_node_contract_with_same_hash_and_node_fails() {
 #[test]
 fn test_create_node_contract_which_was_canceled_before_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         let h = generate_deployment_hash();
@@ -160,6 +166,7 @@ fn test_create_node_contract_which_was_canceled_before_works() {
 #[test]
 fn test_update_node_contract_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_node_contract(
@@ -214,6 +221,7 @@ fn test_update_node_contract_works() {
 #[test]
 fn test_update_node_contract_not_exists_fails() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_noop!(
@@ -231,6 +239,7 @@ fn test_update_node_contract_not_exists_fails() {
 #[test]
 fn test_update_node_contract_wrong_twins_fails() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_node_contract(
@@ -257,6 +266,7 @@ fn test_update_node_contract_wrong_twins_fails() {
 #[test]
 fn test_cancel_node_contract_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_node_contract(
@@ -284,6 +294,7 @@ fn test_cancel_node_contract_works() {
 #[test]
 fn test_create_multiple_node_contracts_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_node_contract(
@@ -330,6 +341,7 @@ fn test_create_multiple_node_contracts_works() {
 #[test]
 fn test_cancel_node_contract_frees_public_ips_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_node_contract(
@@ -369,6 +381,7 @@ fn test_cancel_node_contract_not_exists_fails() {
 #[test]
 fn test_cancel_node_contract_wrong_twins_fails() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_node_contract(
@@ -393,6 +406,7 @@ fn test_cancel_node_contract_wrong_twins_fails() {
 #[test]
 fn test_create_name_contract_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_name_contract(
@@ -405,6 +419,7 @@ fn test_create_name_contract_works() {
 #[test]
 fn test_cancel_name_contract_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_name_contract(
@@ -430,6 +445,7 @@ fn test_cancel_name_contract_works() {
 #[test]
 fn test_create_name_contract_double_with_same_name_fails() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_name_contract(
@@ -449,6 +465,7 @@ fn test_create_name_contract_double_with_same_name_fails() {
 #[test]
 fn test_recreate_name_contract_after_cancel_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_name_contract(
@@ -471,6 +488,7 @@ fn test_recreate_name_contract_after_cancel_works() {
 #[test]
 fn test_create_name_contract_with_invalid_dns_name_fails() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_noop!(
@@ -513,6 +531,7 @@ fn test_create_name_contract_with_invalid_dns_name_fails() {
 #[test]
 fn test_create_rent_contract_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_dedicated_farm_and_node();
 
         let node_id = 1;
@@ -534,6 +553,7 @@ fn test_create_rent_contract_works() {
 #[test]
 fn test_cancel_rent_contract_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_dedicated_farm_and_node();
 
         let node_id = 1;
@@ -563,6 +583,7 @@ fn test_cancel_rent_contract_works() {
 #[test]
 fn test_create_rent_contract_on_node_in_use_fails() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         assert_ok!(SmartContractModule::create_node_contract(
@@ -584,6 +605,7 @@ fn test_create_rent_contract_on_node_in_use_fails() {
 #[test]
 fn test_create_rent_contract_non_dedicated_empty_node_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         let node_id = 1;
@@ -598,6 +620,7 @@ fn test_create_rent_contract_non_dedicated_empty_node_works() {
 #[test]
 fn test_create_node_contract_on_dedicated_node_without_rent_contract_fails() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_dedicated_farm_and_node();
 
         assert_noop!(
@@ -617,6 +640,7 @@ fn test_create_node_contract_on_dedicated_node_without_rent_contract_fails() {
 #[test]
 fn test_create_node_contract_when_having_a_rentcontract_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_dedicated_farm_and_node();
 
         assert_ok!(SmartContractModule::create_rent_contract(
@@ -639,6 +663,7 @@ fn test_create_node_contract_when_having_a_rentcontract_works() {
 #[test]
 fn test_create_node_contract_when_someone_else_has_rent_contract_fails() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_dedicated_farm_and_node();
 
         // create rent contract with bob
@@ -703,7 +728,7 @@ fn test_node_contract_billing_details() {
     let (mut ext, mut pool_state) = new_test_ext_with_pool_state(0);
     ext.execute_with(|| {
         prepare_farm_and_node();
-        run_to_block(0, Some(&mut pool_state));
+        run_to_block(1, Some(&mut pool_state));
         TFTPriceModule::set_prices(Origin::signed(bob()), 50, 101).unwrap();
 
         let twin = TfgridModule::twins(2).unwrap();
@@ -722,13 +747,15 @@ fn test_node_contract_billing_details() {
 
         push_nru_report_for_contract(1, 10);
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(10);
+        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(0);
         assert_eq!(contract_to_bill, [1]);
 
         let initial_total_issuance = Balances::total_issuance();
         // advance 25 cycles
         for i in 0..25 {
-            pool_state.write().should_call_bill_contract(1, Ok(()));
+            pool_state
+                .write()
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
             run_to_block(11 + i * 10, Some(&mut pool_state));
         }
 
@@ -768,9 +795,10 @@ fn test_node_contract_billing_details() {
         let total_issuance = Balances::total_issuance();
         // total issueance is now previous total - amount burned from contract billed (35%)
         let burned_amount = Perbill::from_percent(35) * total_amount_billed;
-        assert_eq!(
+        assert_eq_error_rate!(
             total_issuance,
-            initial_total_issuance - burned_amount as u64
+            initial_total_issuance - burned_amount as u64,
+            1
         );
 
         // amount unbilled should have been reset after a transfer between contract owner and farmer
@@ -787,7 +815,7 @@ fn test_node_contract_billing_details_with_solution_provider() {
 
         prepare_solution_provider();
 
-        run_to_block(0, Some(&mut pool_state));
+        run_to_block(1, Some(&mut pool_state));
         TFTPriceModule::set_prices(Origin::signed(bob()), 50, 101).unwrap();
 
         let twin = TfgridModule::twins(2).unwrap();
@@ -807,12 +835,14 @@ fn test_node_contract_billing_details_with_solution_provider() {
 
         push_nru_report_for_contract(1, 10);
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(10);
+        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(0);
         assert_eq!(contract_to_bill, [1]);
 
         // advance 25 cycles
         for i in 0..25 {
-            pool_state.write().should_call_bill_contract(1, Ok(()));
+            pool_state
+                .write()
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
             run_to_block(11 + i * 10, Some(&mut pool_state));
         }
 
@@ -848,13 +878,17 @@ fn test_multiple_contracts_billing_loop_works() {
             "some_name".as_bytes().to_vec(),
         ));
 
-        let contracts_to_bill_at_block = SmartContractModule::contract_to_bill_at_block(11);
+        let contracts_to_bill_at_block = SmartContractModule::contract_to_bill_at_block(0);
         assert_eq!(contracts_to_bill_at_block.len(), 2);
 
         // 2 contracts => 2 billings
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        pool_state.write().should_call_bill_contract(2, Ok(()));
-        run_to_block(12, Some(&mut pool_state));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        pool_state
+            .write()
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+        run_to_block(11, Some(&mut pool_state));
 
         // Test that the expected events were emitted
         let our_events = System::events();
@@ -888,10 +922,12 @@ fn test_node_contract_billing_cycles() {
 
         push_contract_resources_used(1);
 
-        let (amount_due_1, discount_received) = calculate_tft_cost(contract_id, twin_id, 11);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        run_to_block(12, Some(&mut pool_state));
-        check_report_cost(1, amount_due_1, 12, discount_received);
+        let (amount_due_1, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        run_to_block(11, Some(&mut pool_state));
+        check_report_cost(1, amount_due_1, 11, discount_received);
 
         let twin = TfgridModule::twins(twin_id).unwrap();
         let usable_balance = Balances::usable_balance(&twin.account_id);
@@ -904,14 +940,18 @@ fn test_node_contract_billing_cycles() {
         );
 
         let (amount_due_2, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        run_to_block(22, Some(&mut pool_state));
-        check_report_cost(1, amount_due_2, 22, discount_received);
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        run_to_block(21, Some(&mut pool_state));
+        check_report_cost(1, amount_due_2, 21, discount_received);
 
         let (amount_due_3, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        run_to_block(32, Some(&mut pool_state));
-        check_report_cost(1, amount_due_3, 32, discount_received);
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        run_to_block(31, Some(&mut pool_state));
+        check_report_cost(1, amount_due_3, 31, discount_received);
 
         let twin = TfgridModule::twins(twin_id).unwrap();
         let usable_balance = Balances::usable_balance(&twin.account_id);
@@ -951,8 +991,12 @@ fn test_node_multiple_contract_billing_cycles() {
         ));
         let twin_id = 2;
 
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        pool_state.write().should_call_bill_contract(2, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        pool_state
+            .write()
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
         push_contract_resources_used(1);
         push_contract_resources_used(2);
 
@@ -995,39 +1039,41 @@ fn test_node_contract_billing_cycles_delete_node_cancels_contract() {
         let contract_id = 1;
         let twin_id = 2;
 
-        for i in 0..5 {
-            pool_state.write().should_call_bill_contract(1, Ok(()));
+        for _ in 0..5 {
+            pool_state
+                .write()
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         }
         push_contract_resources_used(1);
 
-        let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 11);
-        run_to_block(12, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 12, discount_received);
+        let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
+        run_to_block(11, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 11, discount_received);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
-        run_to_block(22, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 22, discount_received);
+        run_to_block(21, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 21, discount_received);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
-        run_to_block(32, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 32, discount_received);
+        run_to_block(31, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 31, discount_received);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
-        run_to_block(42, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 42, discount_received);
+        run_to_block(41, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 41, discount_received);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
-        run_to_block(52, Some(&mut pool_state));
-        check_report_cost(1, amount_due_as_u128, 52, discount_received);
+        run_to_block(51, Some(&mut pool_state));
+        check_report_cost(1, amount_due_as_u128, 51, discount_received);
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 4);
-        run_to_block(56, Some(&mut pool_state));
+        run_to_block(55, None);
 
         // Delete node
         TfgridModule::delete_node_farm(Origin::signed(alice()), 1).unwrap();
 
         // After deleting a node, the contract gets billed before it's canceled
-        check_report_cost(1, amount_due_as_u128, 56, discount_received);
+        check_report_cost(1, amount_due_as_u128, 55, discount_received);
 
         let our_events = System::events();
 
@@ -1088,10 +1134,10 @@ fn test_node_contract_only_public_ip_billing_cycles() {
         let contract_id = 1;
         let twin_id = 2;
 
-        for i in 0..5 {
+        for _ in 0..5 {
             pool_state
                 .write()
-                .should_call_bill_contract(contract_id, Ok(()));
+                .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()));
         }
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 11);
@@ -1138,10 +1184,10 @@ fn test_node_contract_billing_cycles_cancel_contract_during_cycle_works() {
         let twin_id = 2;
 
         // 2 cycles for billing
-        for i in 0..2 {
+        for _ in 0..2 {
             pool_state
                 .write()
-                .should_call_bill_contract(contract_id, Ok(()));
+                .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()));
         }
         push_contract_resources_used(1);
 
@@ -1175,9 +1221,9 @@ fn test_node_contract_billing_cycles_cancel_contract_during_cycle_works() {
 fn test_node_contract_billing_fails() {
     let (mut ext, mut pool_state) = new_test_ext_with_pool_state(0);
     ext.execute_with(|| {
+        run_to_block(1, Some(&mut pool_state));
         // Creates a farm and node and sets the price of tft to 0 which raises an error later
         prepare_farm_and_node();
-        run_to_block(1, Some(&mut pool_state));
 
         assert_ok!(SmartContractModule::create_node_contract(
             Origin::signed(bob()),
@@ -1188,7 +1234,7 @@ fn test_node_contract_billing_fails() {
             None
         ));
 
-        let contracts_to_bill_at_block = SmartContractModule::contract_to_bill_at_block(11);
+        let contracts_to_bill_at_block = SmartContractModule::contract_to_bill_at_block(0);
         assert_eq!(contracts_to_bill_at_block.len(), 1);
 
         let contract_id = contracts_to_bill_at_block[0];
@@ -1201,9 +1247,11 @@ fn test_node_contract_billing_fails() {
 
         // the offchain worker should save the failed ids in local storage and try again
         // in subsequent blocks (which will also fail)
-        for i in 0..3 {
-            pool_state.write().should_call_bill_contract(1, Ok(()));
-            run_to_block(12 + i, Some(&mut pool_state));
+        for i in 1..3 {
+            pool_state
+                .write()
+                .should_call_bill_contract(1, Err(Error::<TestRuntime>::TwinNotExists.into()));
+            run_to_block(11 * i, Some(&mut pool_state));
         }
     });
 }
@@ -1235,19 +1283,19 @@ fn test_node_contract_billing_cycles_cancel_contract_during_cycle_without_balanc
 
         push_contract_resources_used(1);
 
-        let (amount_due_1, discount_received) = calculate_tft_cost(contract_id, twin_id, 11);
+        let (amount_due_1, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
         pool_state
             .write()
-            .should_call_bill_contract(contract_id, Ok(()));
-        run_to_block(12, Some(&mut pool_state));
-        check_report_cost(1, amount_due_1, 12, discount_received);
+            .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()));
+        run_to_block(11, Some(&mut pool_state));
+        check_report_cost(1, amount_due_1, 11, discount_received);
 
         let (amount_due_2, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
         pool_state
             .write()
-            .should_call_bill_contract(contract_id, Ok(()));
-        run_to_block(22, Some(&mut pool_state));
-        check_report_cost(1, amount_due_2, 22, discount_received);
+            .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()));
+        run_to_block(21, Some(&mut pool_state));
+        check_report_cost(1, amount_due_2, 21, discount_received);
 
         // Run halfway ish next cycle and cancel
         run_to_block(25, Some(&mut pool_state));
@@ -1271,7 +1319,10 @@ fn test_node_contract_billing_cycles_cancel_contract_during_cycle_without_balanc
             1
         ));
 
-        run_to_block(29, Some(&mut pool_state));
+        pool_state
+            .write()
+            .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()));
+        run_to_block(31, Some(&mut pool_state));
 
         // After canceling contract, and not being able to pay for the remainder of the cycle
         // where the cancel was excecuted, the remaining balance should still be the same
@@ -1305,16 +1356,20 @@ fn test_node_contract_out_of_funds_should_move_state_to_graceperiod_works() {
         push_contract_resources_used(1);
 
         // cycle 1
-        pool_state.write().should_call_bill_contract(1, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         run_to_block(12, Some(&mut pool_state));
 
         // cycle 2
         // user does not have enough funds to pay for 2 cycles
-        pool_state.write().should_call_bill_contract(1, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         run_to_block(22, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(21));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(20));
 
         let our_events = System::events();
         assert_eq!(
@@ -1323,7 +1378,7 @@ fn test_node_contract_out_of_funds_should_move_state_to_graceperiod_works() {
                     contract_id: 1,
                     node_id: 1,
                     twin_id: 3,
-                    block_number: 21
+                    block_number: 20
                 }
             ))),
             true
@@ -1348,8 +1403,10 @@ fn test_restore_node_contract_in_grace_works() {
             None
         ));
 
-        for i in 0..6 {
-            pool_state.write().should_call_bill_contract(1, Ok(()));
+        for _ in 0..6 {
+            pool_state
+                .write()
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         }
         push_contract_resources_used(1);
 
@@ -1361,7 +1418,7 @@ fn test_restore_node_contract_in_grace_works() {
         run_to_block(22, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(21));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(20));
 
         let our_events = System::events();
         assert_eq!(
@@ -1370,29 +1427,17 @@ fn test_restore_node_contract_in_grace_works() {
                     contract_id: 1,
                     node_id: 1,
                     twin_id: 3,
-                    block_number: 21
+                    block_number: 20
                 }
             ))),
             true
         );
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(31);
-        assert_eq!(contract_to_bill.len(), 1);
         run_to_block(32, Some(&mut pool_state));
-
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(41);
-        assert_eq!(contract_to_bill.len(), 1);
         run_to_block(42, Some(&mut pool_state));
-
         // Transfer some balance to the owner of the contract to trigger the grace period to stop
         Balances::transfer(Origin::signed(bob()), charlie(), 100000000).unwrap();
-
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(51);
-        assert_eq!(contract_to_bill.len(), 1);
         run_to_block(52, Some(&mut pool_state));
-
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(61);
-        assert_eq!(contract_to_bill.len(), 1);
         run_to_block(62, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
@@ -1420,16 +1465,20 @@ fn test_node_contract_grace_period_cancels_contract_when_grace_period_ends_works
         push_contract_resources_used(1);
 
         // cycle 1
-        pool_state.write().should_call_bill_contract(1, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         run_to_block(12, Some(&mut pool_state));
 
         // cycle 2
         // user does not have enough funds to pay for 2 cycles
-        pool_state.write().should_call_bill_contract(1, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         run_to_block(22, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(21));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(20));
 
         let our_events = System::events();
         assert_eq!(
@@ -1438,15 +1487,17 @@ fn test_node_contract_grace_period_cancels_contract_when_grace_period_ends_works
                     contract_id: 1,
                     node_id: 1,
                     twin_id: 3,
-                    block_number: 21
+                    block_number: 20
                 }
             ))),
             true
         );
 
         // grace period stops after 100 blocknumbers, so after 121
-        for i in 0..10 {
-            pool_state.write().should_call_bill_contract(1, Ok(()));
+        for _ in 0..11 {
+            pool_state
+                .write()
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         }
         for i in 0..11 {
             run_to_block(32 + i * 10, Some(&mut pool_state));
@@ -1470,12 +1521,14 @@ fn test_name_contract_billing() {
             "foobar".as_bytes().to_vec()
         ));
 
-        let contracts_to_bill = SmartContractModule::contract_to_bill_at_block(1);
+        let contracts_to_bill = SmartContractModule::contract_to_bill_at_block(0);
         assert_eq!(contracts_to_bill, [1]);
 
         // let mature 11 blocks
         // because we bill every 10 blocks
-        pool_state.write().should_call_bill_contract(1, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         run_to_block(11, Some(&mut pool_state));
 
         // the contractbill event should look like:
@@ -1520,7 +1573,9 @@ fn test_rent_contract_billing() {
             types::ContractData::RentContract(rent_contract)
         );
 
-        pool_state.write().should_call_bill_contract(1, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         run_to_block(11, Some(&mut pool_state));
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 10);
@@ -1551,7 +1606,9 @@ fn test_rent_contract_billing_cancel_should_bill_reserved_balance() {
             types::ContractData::RentContract(rent_contract)
         );
 
-        pool_state.write().should_call_bill_contract(1, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         run_to_block(11, Some(&mut pool_state));
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 10);
@@ -1581,11 +1638,15 @@ fn test_rent_contract_billing_cancel_should_bill_reserved_balance() {
         // we do not call bill contract here as the contract is removed during
         // cancel_contract. The contract id will still be in ContractsToBillAt
         // but the contract itself will no longer exist
+        // But the
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         run_to_block(22, Some(&mut pool_state));
 
         // Last amount due is the same as the first one
         assert_ne!(amount_due_as_u128, 0);
-        check_report_cost(1, amount_due_as_u128, 14, discount_received);
+        check_report_cost(1, amount_due_as_u128, 13, discount_received);
 
         let usable_balance = Balances::usable_balance(&twin.account_id);
         let free_balance = Balances::free_balance(&twin.account_id);
@@ -1665,13 +1726,17 @@ fn test_create_rent_contract_and_node_contract_excludes_node_contract_from_billi
             None
         ));
         push_contract_resources_used(2);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        pool_state.write().should_call_bill_contract(2, Ok(()));
-        run_to_block(12, Some(&mut pool_state));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        pool_state
+            .write()
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+        run_to_block(11, Some(&mut pool_state));
 
-        let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 11);
+        let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 10);
         assert_ne!(amount_due_as_u128, 0);
-        check_report_cost(1, amount_due_as_u128, 12, discount_received);
+        check_report_cost(1, amount_due_as_u128, 11, discount_received);
 
         let our_events = System::events();
         // Event 1: Rent contract created
@@ -1708,11 +1773,15 @@ fn test_rent_contract_canceled_due_to_out_of_funds_should_cancel_node_contracts_
         push_contract_resources_used(2);
 
         // run 12 cycles, contracts should cancel after 11 due to lack of funds
-        for i in 0..11 {
-            pool_state.write().should_call_bill_contract(1, Ok(()));
-            pool_state.write().should_call_bill_contract(2, Ok(()));
+        for _ in 0..11 {
+            pool_state
+                .write()
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            pool_state
+                .write()
+                .should_call_bill_contract(2, Ok(Pays::Yes.into()));
         }
-        for i in 0..12 {
+        for i in 0..11 {
             run_to_block(12 + 10 * i, Some(&mut pool_state));
         }
 
@@ -1740,7 +1809,7 @@ fn test_rent_contract_canceled_due_to_out_of_funds_should_cancel_node_contracts_
                 contract_id: 1,
                 node_id: 1,
                 twin_id: 3,
-                block_number: 11
+                block_number: 10
             }))
         );
         assert_eq!(
@@ -1751,7 +1820,7 @@ fn test_rent_contract_canceled_due_to_out_of_funds_should_cancel_node_contracts_
                 contract_id: 2,
                 node_id: 1,
                 twin_id: 3,
-                block_number: 11
+                block_number: 10
             }))
         );
 
@@ -1801,18 +1870,22 @@ fn test_create_rent_contract_and_node_contract_with_ip_billing_works() {
         ));
 
         // 2 contracts => we expect 2 calls to bill_contract
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        pool_state.write().should_call_bill_contract(2, Ok(()));
-        run_to_block(12, Some(&mut pool_state));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        pool_state
+            .write()
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+        run_to_block(11, Some(&mut pool_state));
 
         // check contract 1 costs (Rent Contract)
-        let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 11);
+        let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 10);
         assert_ne!(amount_due_as_u128, 0);
-        check_report_cost(1, amount_due_as_u128, 12, discount_received);
+        check_report_cost(1, amount_due_as_u128, 11, discount_received);
         // check contract 2 costs (Node Contract)
-        let (amount_due_as_u128, discount_received) = calculate_tft_cost(2, 2, 11);
+        let (amount_due_as_u128, discount_received) = calculate_tft_cost(2, 2, 10);
         assert_ne!(amount_due_as_u128, 0);
-        check_report_cost(2, amount_due_as_u128, 12, discount_received);
+        check_report_cost(2, amount_due_as_u128, 11, discount_received);
 
         let our_events = System::events();
         // Event 1: Price Stored
@@ -1842,11 +1915,13 @@ fn test_rent_contract_out_of_funds_should_move_state_to_graceperiod_works() {
 
         // cycle 1
         // user does not have enough funds to pay for 1 cycle
-        pool_state.write().should_call_bill_contract(1, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         run_to_block(12, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(11));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(10));
 
         let our_events = System::events();
         assert_eq!(
@@ -1855,7 +1930,7 @@ fn test_rent_contract_out_of_funds_should_move_state_to_graceperiod_works() {
                     contract_id: 1,
                     node_id: 1,
                     twin_id: 3,
-                    block_number: 11
+                    block_number: 10
                 }
             ))),
             true
@@ -1879,11 +1954,13 @@ fn test_restore_rent_contract_in_grace_works() {
         ));
 
         // cycle 1
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        run_to_block(12, Some(&mut pool_state));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        run_to_block(11, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(11));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(10));
 
         let our_events = System::events();
         assert_eq!(
@@ -1894,31 +1971,31 @@ fn test_restore_rent_contract_in_grace_works() {
                 contract_id: 1,
                 node_id: 1,
                 twin_id: 3,
-                block_number: 11
+                block_number: 10
             }))
         );
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(21);
-        assert_eq!(contract_to_bill.len(), 1);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        run_to_block(22, Some(&mut pool_state));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        run_to_block(21, Some(&mut pool_state));
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(31);
-        assert_eq!(contract_to_bill.len(), 1);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        run_to_block(32, Some(&mut pool_state));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        run_to_block(31, Some(&mut pool_state));
 
         // Transfer some balance to the owner of the contract to trigger the grace period to stop
         Balances::transfer(Origin::signed(bob()), charlie(), 100000000).unwrap();
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(41);
-        assert_eq!(contract_to_bill.len(), 1);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        run_to_block(42, Some(&mut pool_state));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        run_to_block(41, Some(&mut pool_state));
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(51);
-        assert_eq!(contract_to_bill.len(), 1);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         run_to_block(52, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
@@ -1951,12 +2028,16 @@ fn test_restore_rent_contract_and_node_contracts_in_grace_works() {
         push_contract_resources_used(2);
 
         // cycle 1
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        pool_state.write().should_call_bill_contract(2, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        pool_state
+            .write()
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
         run_to_block(12, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(11));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(10));
 
         let our_events = System::events();
         assert_eq!(
@@ -1967,7 +2048,7 @@ fn test_restore_rent_contract_and_node_contracts_in_grace_works() {
                 contract_id: 1,
                 node_id: 1,
                 twin_id: 3,
-                block_number: 11
+                block_number: 10
             }))
         );
         assert_eq!(
@@ -1978,35 +2059,43 @@ fn test_restore_rent_contract_and_node_contracts_in_grace_works() {
                 contract_id: 2,
                 node_id: 1,
                 twin_id: 3,
-                block_number: 11
+                block_number: 10
             }))
         );
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(21);
-        assert_eq!(contract_to_bill.len(), 2);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        pool_state.write().should_call_bill_contract(2, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        pool_state
+            .write()
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
         run_to_block(22, Some(&mut pool_state));
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(31);
-        assert_eq!(contract_to_bill.len(), 2);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        pool_state.write().should_call_bill_contract(2, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        pool_state
+            .write()
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
         run_to_block(32, Some(&mut pool_state));
 
         // Transfer some balance to the owner of the contract to trigger the grace period to stop
         Balances::transfer(Origin::signed(bob()), charlie(), 100000000).unwrap();
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(41);
-        assert_eq!(contract_to_bill.len(), 2);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        pool_state.write().should_call_bill_contract(2, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        pool_state
+            .write()
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
         run_to_block(42, Some(&mut pool_state));
 
-        let contract_to_bill = SmartContractModule::contract_to_bill_at_block(51);
-        assert_eq!(contract_to_bill.len(), 2);
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        pool_state.write().should_call_bill_contract(2, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        pool_state
+            .write()
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
         run_to_block(52, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
@@ -2052,11 +2141,13 @@ fn test_rent_contract_grace_period_cancels_contract_when_grace_period_ends_works
         ));
 
         // cycle 1
-        pool_state.write().should_call_bill_contract(1, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         run_to_block(12, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
-        assert_eq!(c1.state, types::ContractState::GracePeriod(11));
+        assert_eq!(c1.state, types::ContractState::GracePeriod(10));
 
         let our_events = System::events();
         assert_eq!(
@@ -2065,7 +2156,7 @@ fn test_rent_contract_grace_period_cancels_contract_when_grace_period_ends_works
                     contract_id: 1,
                     node_id: 1,
                     twin_id: 3,
-                    block_number: 11
+                    block_number: 10
                 }
             ))),
             true
@@ -2073,8 +2164,10 @@ fn test_rent_contract_grace_period_cancels_contract_when_grace_period_ends_works
 
         // run 12 cycles, after 10 cycles grace period has finished so no more
         // billing!
-        for i in 0..10 {
-            pool_state.write().should_call_bill_contract(1, Ok(()));
+        for _ in 0..11 {
+            pool_state
+                .write()
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
         }
         for i in 0..12 {
             run_to_block(22 + i * 10, Some(&mut pool_state));
@@ -2111,8 +2204,12 @@ fn test_rent_contract_and_node_contract_canceled_when_node_is_deleted_works() {
         push_contract_resources_used(2);
 
         // 2 contracts => 2 calls to bill_contract
-        pool_state.write().should_call_bill_contract(1, Ok(()));
-        pool_state.write().should_call_bill_contract(2, Ok(()));
+        pool_state
+            .write()
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+        pool_state
+            .write()
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
         run_to_block(12, Some(&mut pool_state));
 
         run_to_block(16, Some(&mut pool_state));
@@ -2199,6 +2296,7 @@ fn test_create_solution_provider_fails_if_take_to_high() {
 #[test]
 fn test_create_node_contract_with_solution_provider_works() {
     new_test_ext().execute_with(|| {
+        run_to_block(1, None);
         prepare_farm_and_node();
 
         prepare_solution_provider();
@@ -2441,14 +2539,6 @@ fn check_report_cost(
         ))),
         true
     );
-    // assert_eq!(
-    //     our_events[index],
-    //     record(MockEvent::SmartContractModule(SmartContractEvent::<
-    //         TestRuntime,
-    //     >::ContractBilled(
-    //         contract_bill_event
-    //     )))
-    // );
 }
 
 fn calculate_tft_cost(contract_id: u64, twin_id: u32, blocks: u64) -> (u64, types::DiscountLevel) {

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -14,6 +14,7 @@ use sp_std::convert::{TryFrom, TryInto};
 use substrate_fixed::types::U64F64;
 
 use crate::cost;
+use log::info;
 use pallet_tfgrid::types as pallet_tfgrid_types;
 use tfchain_support::types::{FarmCertification, Location, NodeCertification, PublicIP, Resources};
 
@@ -761,12 +762,12 @@ fn test_node_contract_billing_details() {
 
         let free_balance = Balances::free_balance(&twin.account_id);
         let total_amount_billed = initial_twin_balance - free_balance;
-        println!("locked balance {:?}", total_amount_billed);
+        info!("locked balance {:?}", total_amount_billed);
 
-        println!("total locked balance {:?}", total_amount_billed);
+        info!("total locked balance {:?}", total_amount_billed);
 
         let staking_pool_account_balance = Balances::free_balance(&get_staking_pool_account());
-        println!(
+        info!(
             "staking pool account balance, {:?}",
             staking_pool_account_balance
         );
@@ -1078,7 +1079,7 @@ fn test_node_contract_billing_cycles_delete_node_cancels_contract() {
         let our_events = System::events();
 
         for e in our_events.clone().iter() {
-            println!("{:?}", e);
+            info!("{:?}", e);
         }
 
         let public_ip = PublicIP {
@@ -1266,7 +1267,7 @@ fn test_node_contract_billing_cycles_cancel_contract_during_cycle_without_balanc
 
         let twin = TfgridModule::twins(2).unwrap();
         let initial_twin_balance = Balances::free_balance(&twin.account_id);
-        println!("initial twin balance: {:?}", initial_twin_balance);
+        info!("initial twin balance: {:?}", initial_twin_balance);
         let initial_total_issuance = Balances::total_issuance();
 
         assert_ok!(SmartContractModule::create_node_contract(
@@ -1539,7 +1540,7 @@ fn test_name_contract_billing() {
             amount_billed: 1848,
         };
         let our_events = System::events();
-        println!("events: {:?}", our_events.clone());
+        info!("events: {:?}", our_events.clone());
         assert_eq!(
             our_events[3],
             record(MockEvent::SmartContractModule(SmartContractEvent::<
@@ -1681,7 +1682,7 @@ fn test_rent_contract_canceled_mid_cycle_should_bill_for_remainder() {
         let free_balance = Balances::free_balance(&twin.account_id);
 
         let locked_balance = free_balance - usable_balance;
-        println!("locked balance: {:?}", locked_balance);
+        info!("locked balance: {:?}", locked_balance);
 
         run_to_block(8, Some(&mut pool_state));
         // Calculate the cost for 7 blocks of runtime (created a block 1, canceled at block 8)
@@ -2422,10 +2423,10 @@ fn validate_distribution_rewards(
     total_amount_billed: u64,
     had_solution_provider: bool,
 ) {
-    println!("total locked balance {:?}", total_amount_billed);
+    info!("total locked balance {:?}", total_amount_billed);
 
     let staking_pool_account_balance = Balances::free_balance(&get_staking_pool_account());
-    println!(
+    info!(
         "staking pool account balance, {:?}",
         staking_pool_account_balance
     );
@@ -2456,7 +2457,7 @@ fn validate_distribution_rewards(
         let solution_provider = SmartContractModule::solution_providers(1).unwrap();
         let solution_provider_1_balance =
             Balances::free_balance(solution_provider.providers[0].who.clone());
-        println!("solution provider b: {:?}", solution_provider_1_balance);
+        info!("solution provider b: {:?}", solution_provider_1_balance);
         assert_eq!(
             solution_provider_1_balance,
             Perbill::from_percent(10) * total_amount_billed
@@ -2521,10 +2522,6 @@ fn check_report_cost(
     discount_level: types::DiscountLevel,
 ) {
     let our_events = System::events();
-
-    for e in our_events.clone().iter() {
-        println!("event: {:?}", e);
-    }
 
     let contract_bill_event = types::ContractBill {
         contract_id,

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -756,7 +756,7 @@ fn test_node_contract_billing_details() {
         for i in 0..25 {
             pool_state
                 .write()
-                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11 + i * 10);
             run_to_block(11 + i * 10, Some(&mut pool_state));
         }
 
@@ -843,7 +843,7 @@ fn test_node_contract_billing_details_with_solution_provider() {
         for i in 0..25 {
             pool_state
                 .write()
-                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11 + i * 10);
             run_to_block(11 + i * 10, Some(&mut pool_state));
         }
 
@@ -885,10 +885,10 @@ fn test_multiple_contracts_billing_loop_works() {
         // 2 contracts => 2 billings
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         pool_state
             .write()
-            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
 
         // Test that the expected events were emitted
@@ -926,7 +926,7 @@ fn test_node_contract_billing_cycles() {
         let (amount_due_1, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
         check_report_cost(1, amount_due_1, 11, discount_received);
 
@@ -943,14 +943,14 @@ fn test_node_contract_billing_cycles() {
         let (amount_due_2, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 21);
         run_to_block(21, Some(&mut pool_state));
         check_report_cost(1, amount_due_2, 21, discount_received);
 
         let (amount_due_3, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 31);
         run_to_block(31, Some(&mut pool_state));
         check_report_cost(1, amount_due_3, 31, discount_received);
 
@@ -994,10 +994,10 @@ fn test_node_multiple_contract_billing_cycles() {
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         pool_state
             .write()
-            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()), 11);
         push_contract_resources_used(1);
         push_contract_resources_used(2);
 
@@ -1040,10 +1040,10 @@ fn test_node_contract_billing_cycles_delete_node_cancels_contract() {
         let contract_id = 1;
         let twin_id = 2;
 
-        for _ in 0..5 {
+        for i in 0..5 {
             pool_state
                 .write()
-                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11 + i * 10);
         }
         push_contract_resources_used(1);
 
@@ -1135,10 +1135,12 @@ fn test_node_contract_only_public_ip_billing_cycles() {
         let contract_id = 1;
         let twin_id = 2;
 
-        for _ in 0..5 {
-            pool_state
-                .write()
-                .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()));
+        for i in 0..5 {
+            pool_state.write().should_call_bill_contract(
+                contract_id,
+                Ok(Pays::Yes.into()),
+                11 + i * 10,
+            );
         }
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
@@ -1185,10 +1187,12 @@ fn test_node_contract_billing_cycles_cancel_contract_during_cycle_works() {
         let twin_id = 2;
 
         // 2 cycles for billing
-        for _ in 0..2 {
-            pool_state
-                .write()
-                .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()));
+        for i in 0..2 {
+            pool_state.write().should_call_bill_contract(
+                contract_id,
+                Ok(Pays::Yes.into()),
+                11 + i * 10,
+            );
         }
         push_contract_resources_used(1);
 
@@ -1249,9 +1253,11 @@ fn test_node_contract_billing_fails() {
         // the offchain worker should save the failed ids in local storage and try again
         // in subsequent blocks (which will also fail)
         for i in 1..3 {
-            pool_state
-                .write()
-                .should_call_bill_contract(1, Err(Error::<TestRuntime>::TwinNotExists.into()));
+            pool_state.write().should_call_bill_contract(
+                1,
+                Err(Error::<TestRuntime>::TwinNotExists.into()),
+                1 + i * 10,
+            );
             run_to_block(11 * i, Some(&mut pool_state));
         }
     });
@@ -1287,14 +1293,14 @@ fn test_node_contract_billing_cycles_cancel_contract_during_cycle_without_balanc
         let (amount_due_1, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
         pool_state
             .write()
-            .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
         check_report_cost(1, amount_due_1, 11, discount_received);
 
         let (amount_due_2, discount_received) = calculate_tft_cost(contract_id, twin_id, 10);
         pool_state
             .write()
-            .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()), 21);
         run_to_block(21, Some(&mut pool_state));
         check_report_cost(1, amount_due_2, 21, discount_received);
 
@@ -1322,7 +1328,7 @@ fn test_node_contract_billing_cycles_cancel_contract_during_cycle_without_balanc
 
         pool_state
             .write()
-            .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(contract_id, Ok(Pays::Yes.into()), 31);
         run_to_block(31, Some(&mut pool_state));
 
         // After canceling contract, and not being able to pay for the remainder of the cycle
@@ -1359,14 +1365,14 @@ fn test_node_contract_out_of_funds_should_move_state_to_graceperiod_works() {
         // cycle 1
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
 
         // cycle 2
         // user does not have enough funds to pay for 2 cycles
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 21);
         run_to_block(21, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
@@ -1404,10 +1410,10 @@ fn test_restore_node_contract_in_grace_works() {
             None
         ));
 
-        for _ in 0..6 {
+        for i in 0..6 {
             pool_state
                 .write()
-                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11 + i * 10);
         }
         push_contract_resources_used(1);
 
@@ -1468,14 +1474,14 @@ fn test_node_contract_grace_period_cancels_contract_when_grace_period_ends_works
         // cycle 1
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
 
         // cycle 2
         // user does not have enough funds to pay for 2 cycles
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 21);
         run_to_block(21, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
@@ -1495,10 +1501,10 @@ fn test_node_contract_grace_period_cancels_contract_when_grace_period_ends_works
         );
 
         // grace period stops after 100 blocknumbers, so after 121
-        for _ in 1..10 {
+        for i in 1..10 {
             pool_state
                 .write()
-                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()), 21 + i * 10);
         }
 
         for i in 1..10 {
@@ -1507,7 +1513,7 @@ fn test_node_contract_grace_period_cancels_contract_when_grace_period_ends_works
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 121);
         run_to_block(121, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1);
@@ -1535,7 +1541,7 @@ fn test_name_contract_billing() {
         // because we bill every 10 blocks
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
 
         // the contractbill event should look like:
@@ -1582,7 +1588,7 @@ fn test_rent_contract_billing() {
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 10);
@@ -1615,7 +1621,7 @@ fn test_rent_contract_billing_cancel_should_bill_reserved_balance() {
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 10);
@@ -1648,7 +1654,7 @@ fn test_rent_contract_billing_cancel_should_bill_reserved_balance() {
         // But the
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 21);
         run_to_block(22, Some(&mut pool_state));
 
         // Last amount due is the same as the first one
@@ -1735,10 +1741,10 @@ fn test_create_rent_contract_and_node_contract_excludes_node_contract_from_billi
         push_contract_resources_used(2);
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         pool_state
             .write()
-            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
 
         let (amount_due_as_u128, discount_received) = calculate_tft_cost(1, 2, 10);
@@ -1780,13 +1786,13 @@ fn test_rent_contract_canceled_due_to_out_of_funds_should_cancel_node_contracts_
         push_contract_resources_used(2);
 
         // run 12 cycles, contracts should cancel after 11 due to lack of funds
-        for _ in 0..11 {
+        for i in 0..11 {
             pool_state
                 .write()
-                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11 + i * 10);
             pool_state
                 .write()
-                .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+                .should_call_bill_contract(2, Ok(Pays::Yes.into()), 11 + i * 10);
         }
         for i in 0..11 {
             run_to_block(12 + 10 * i, Some(&mut pool_state));
@@ -1883,10 +1889,10 @@ fn test_create_rent_contract_and_node_contract_with_ip_billing_works() {
         // 2 contracts => we expect 2 calls to bill_contract
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         pool_state
             .write()
-            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
 
         // check contract 1 costs (Rent Contract)
@@ -1928,7 +1934,7 @@ fn test_rent_contract_out_of_funds_should_move_state_to_graceperiod_works() {
         // user does not have enough funds to pay for 1 cycle
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
@@ -1967,7 +1973,7 @@ fn test_restore_rent_contract_in_grace_works() {
         // cycle 1
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
@@ -1988,12 +1994,12 @@ fn test_restore_rent_contract_in_grace_works() {
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 21);
         run_to_block(21, Some(&mut pool_state));
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 31);
         run_to_block(31, Some(&mut pool_state));
 
         // Transfer some balance to the owner of the contract to trigger the grace period to stop
@@ -2001,13 +2007,13 @@ fn test_restore_rent_contract_in_grace_works() {
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 41);
         run_to_block(41, Some(&mut pool_state));
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
-        run_to_block(52, Some(&mut pool_state));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 51);
+        run_to_block(51, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
         assert_eq!(c1.state, types::ContractState::Created);
@@ -2041,10 +2047,10 @@ fn test_restore_rent_contract_and_node_contracts_in_grace_works() {
         // cycle 1
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         pool_state
             .write()
-            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()), 11);
         run_to_block(11, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
@@ -2076,18 +2082,18 @@ fn test_restore_rent_contract_and_node_contracts_in_grace_works() {
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 21);
         pool_state
             .write()
-            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()), 21);
         run_to_block(22, Some(&mut pool_state));
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 31);
         pool_state
             .write()
-            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()), 31);
         run_to_block(32, Some(&mut pool_state));
 
         // Transfer some balance to the owner of the contract to trigger the grace period to stop
@@ -2095,18 +2101,18 @@ fn test_restore_rent_contract_and_node_contracts_in_grace_works() {
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 41);
         pool_state
             .write()
-            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()), 41);
         run_to_block(42, Some(&mut pool_state));
 
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 51);
         pool_state
             .write()
-            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()), 51);
         run_to_block(52, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
@@ -2155,8 +2161,8 @@ fn test_rent_contract_grace_period_cancels_contract_when_grace_period_ends_works
         // cycle 1
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
-        run_to_block(12, Some(&mut pool_state));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
+        run_to_block(11, Some(&mut pool_state));
 
         let c1 = SmartContractModule::contracts(1).unwrap();
         assert_eq!(c1.state, types::ContractState::GracePeriod(11));
@@ -2176,13 +2182,13 @@ fn test_rent_contract_grace_period_cancels_contract_when_grace_period_ends_works
 
         // run 12 cycles, after 10 cycles grace period has finished so no more
         // billing!
-        for _ in 0..11 {
+        for i in 0..11 {
             pool_state
                 .write()
-                .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+                .should_call_bill_contract(1, Ok(Pays::Yes.into()), 21 + i * 10);
         }
         for i in 0..12 {
-            run_to_block(22 + i * 10, Some(&mut pool_state));
+            run_to_block(21 + i * 10, Some(&mut pool_state));
         }
 
         let c1 = SmartContractModule::contracts(1);
@@ -2218,11 +2224,11 @@ fn test_rent_contract_and_node_contract_canceled_when_node_is_deleted_works() {
         // 2 contracts => 2 calls to bill_contract
         pool_state
             .write()
-            .should_call_bill_contract(1, Ok(Pays::Yes.into()));
+            .should_call_bill_contract(1, Ok(Pays::Yes.into()), 11);
         pool_state
             .write()
-            .should_call_bill_contract(2, Ok(Pays::Yes.into()));
-        run_to_block(12, Some(&mut pool_state));
+            .should_call_bill_contract(2, Ok(Pays::Yes.into()), 11);
+        run_to_block(11, Some(&mut pool_state));
 
         run_to_block(16, Some(&mut pool_state));
 

--- a/substrate-node/pallets/pallet-smart-contract/src/types.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/types.rs
@@ -19,11 +19,12 @@ pub enum StorageVersion {
     V3,
     V4,
     V5,
+    V6,
 }
 
 impl Default for StorageVersion {
     fn default() -> StorageVersion {
-        StorageVersion::V3
+        StorageVersion::V5
     }
 }
 

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -757,7 +757,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (),
+    pallet_smart_contract::migration::v5::ContractMigrationV5<Runtime>,
 >;
 
 impl_runtime_apis! {

--- a/substrate-node/tests/SubstrateNetwork.py
+++ b/substrate-node/tests/SubstrateNetwork.py
@@ -128,7 +128,7 @@ class SubstrateNetwork:
         self._nodes["alice"] = run_node(log_file_alice, "/tmp/alice", "alice", port, ws_port,
                                         rpc_port, node_key="0000000000000000000000000000000000000000000000000000000000000001")
         wait_till_node_ready(log_file_alice)
-        setup_offchain_workers(ws_port)
+        setup_offchain_workers(ws_port, "Alice", "Bob")
 
         log_file = ""
         for x in range(1, amt):
@@ -140,7 +140,7 @@ class SubstrateNetwork:
             self._nodes[name] = run_node(log_file, f"/tmp/{name}", name, port, ws_port, rpc_port, node_key=None,
                                          bootnodes="/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp")
             wait_till_node_ready(log_file)
-            setup_offchain_workers(ws_port)
+            setup_offchain_workers(ws_port, "Bob", "Alice")
 
         logging.info("Network is up and running.")
 

--- a/substrate-node/tests/integration_tests.robot
+++ b/substrate-node/tests/integration_tests.robot
@@ -478,7 +478,6 @@ Test Solution Provider
     Wait X Blocks    ${6}
     # Cancel the contract so that the bill is distributed and so that the providers get their part
     Cancel Node Contract    contract_id=${1}    who=Bob
-    Wait X Blocks    ${2}
 
     # Verification: both providers should have received their part
     ${balance_charlie_after} =     Balance Data    who=Charlie

--- a/substrate-node/tests/integration_tests.robot
+++ b/substrate-node/tests/integration_tests.robot
@@ -478,6 +478,7 @@ Test Solution Provider
     Wait X Blocks    ${6}
     # Cancel the contract so that the bill is distributed and so that the providers get their part
     Cancel Node Contract    contract_id=${1}    who=Bob
+    Wait X Blocks    ${1}
 
     # Verification: both providers should have received their part
     ${balance_charlie_after} =     Balance Data    who=Charlie

--- a/substrate-node/tests/integration_tests.robot
+++ b/substrate-node/tests/integration_tests.robot
@@ -478,7 +478,7 @@ Test Solution Provider
     Wait X Blocks    ${6}
     # Cancel the contract so that the bill is distributed and so that the providers get their part
     Cancel Node Contract    contract_id=${1}    who=Bob
-    Wait X Blocks    ${1}
+    Wait X Blocks    ${2}
 
     # Verification: both providers should have received their part
     ${balance_charlie_after} =     Balance Data    who=Charlie


### PR DESCRIPTION
Contracts will not get reinserted after a successful bill, rather it will get a index which can be calculated as following:

`Now block % billing frequency`

When a contract is created the index is generated as:

`Now block - 1 % billing frequency`

For such, the offchain worker will not bill the contract in the same block it gets created.

Even if the offchain worker now fails to bill the contract, it can be billed in the next cycle. The elapsed time between the first bill (or creation) and next bill is calculated anyway.