### PR TITLE
feat: refactor deployment contract type

### DIFF
--- a/substrate-node/pallets/pallet-smart-contract/src/cost.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/cost.rs
@@ -53,10 +53,6 @@ impl<T: Config> Contract<T> {
         seconds_elapsed: u64,
     ) -> Result<u64, DispatchErrorWithPostInfo> {
         let total_cost = match &self.contract_type {
-            types::ContractData::DeploymentContract(_) => {
-                // cost is calculated in capacity reservation contracts
-                0
-            }
             types::ContractData::CapacityReservationContract(capacity_reservation_contract) => {
                 // Get the contract billing info to view the amount unbilled for NRU (network resource units)
                 let contract_billing_info = self.get_billing_info();

--- a/substrate-node/pallets/pallet-smart-contract/src/migrations/v7.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/migrations/v7.rs
@@ -1,7 +1,7 @@
 use crate::{
     types::{
         CapacityReservationContract, Contract, ContractBillingInformation, ContractData,
-        ContractState, DeploymentContract, NameContract, StorageVersion,
+        ContractState, Deployment, NameContract, StorageVersion,
     },
     ActiveNodeContracts, ActiveRentContractForNode, BalanceOf, BillingFrequency, Config,
     ContractBillingInformationByID, ContractID, ContractLock, Contracts as ContractsV7,
@@ -176,7 +176,7 @@ pub fn post_migration_checks<T: Config>() {
                     contract.contract_id
                 );
             }
-            ContractData::DeploymentContract(dc) => {
+            ContractData::Deployment(dc) => {
                 assert!(
                     !is_in_contracts_to_bill::<T>(contract.contract_id), 
                     "Deployment contract with id {:?} should not be in ContractsToBill!", 
@@ -199,7 +199,7 @@ pub fn post_migration_checks<T: Config>() {
                 for dc_id in crc.deployment_contracts {
                     let ctr = ContractsV7::<T>::get(dc_id).unwrap();
                     let dc = match ctr.contract_type {
-                        ContractData::DeploymentContract(dc) => Some(dc),
+                        ContractData::Deployment(dc) => Some(dc),
                         _ => None,
                     }
                     .unwrap();
@@ -330,7 +330,7 @@ pub fn remove_deployment_contracts_from_contracts_to_bill<T: Config>(
         let mut modified = false;
         contract_ids.retain(|id| {
             if let Some(c) = contracts.get(id) {
-                let res = !matches!(c.contract_type, ContractData::DeploymentContract(_));
+                let res = !matches!(c.contract_type, ContractData::Deployment(_));
                 modified |= res;
                 res
             } else {
@@ -393,7 +393,7 @@ pub fn translate_contract_objects<T: Config>(
                 bill_index_per_contract_id.remove(&ctr.contract_id);
 
                 // create the deployment contract
-                let dc = DeploymentContract {
+                let dc = Deployment {
                     capacity_reservation_id: crc_id,
                     deployment_hash: nc.deployment_hash,
                     deployment_data: nc.deployment_data.clone(),
@@ -435,7 +435,7 @@ pub fn translate_contract_objects<T: Config>(
                         contract_lock: contract_lock_dc,
                     });
 
-                ContractData::DeploymentContract(dc)
+                ContractData::Deployment(dc)
             }
             deprecated::ContractData::NameContract(nc) => {
                 ContractData::NameContract(NameContract { name: nc.name })

--- a/substrate-node/pallets/pallet-smart-contract/src/migrations/v7.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/migrations/v7.rs
@@ -1,11 +1,13 @@
 use crate::{
     types::{
         CapacityReservationContract, Contract, ContractBillingInformation, ContractData,
-        ContractState, Deployment, NameContract, StorageVersion,
+        Deployment, NameContract, StorageVersion,
     },
+    
     ActiveNodeContracts, ActiveRentContractForNode, BalanceOf, BillingFrequency, Config,
     ContractBillingInformationByID, ContractID, ContractLock, Contracts as ContractsV7,
-    ContractsToBillAt, NodeContractResources, Pallet, PalletVersion, CONTRACT_VERSION,
+    ContractsToBillAt, DeploymentID, Deployments, NodeContractResources, Pallet, 
+    PalletVersion, CONTRACT_VERSION,
 };
 use frame_support::{
     pallet_prelude::OptionQuery, pallet_prelude::Weight, storage_alias, traits::Get,
@@ -118,7 +120,7 @@ pub struct NodeChanges {
 pub struct ContractChanges<T: Config> {
     pub used_resources: Resources,
     pub public_ips: u32,
-    pub deployment_contracts: Vec<u64>,
+    pub deployments: Vec<u64>,
     pub contract_lock: crate::types::ContractLock<BalanceOf<T>>,
     pub billing_info: ContractBillingInformation,
 }
@@ -128,7 +130,12 @@ impl<T: Config> OnRuntimeUpgrade for ContractMigrationV6<T> {
     fn pre_upgrade() -> Result<(), &'static str> {
         info!("current pallet version: {:?}", PalletVersion::<T>::get());
         let contract_counts: u64 = Contracts::<T>::iter_keys().count() as u64;
-        Self::set_temp_storage(contract_counts, "pre_contract_count");
+        let mut expected_contract_count_after_migration = contract_counts;
+        // all node contracts that were part of a rent contract will not be transformed into a capacity reservation contract
+        for (node_id, _) in ActiveRentContractForNode::<T>::iter() {
+            expected_contract_count_after_migration -= ActiveNodeContracts::<T>::get(node_id).len() as u64;
+        }
+        Self::set_temp_storage(expected_contract_count_after_migration, "expected_contract_count_after_migration");
         info!(
             "👥  Smart Contract pallet to V6 passes PRE migrate checks ✅: {:?} contracts",
             contract_counts
@@ -147,17 +154,16 @@ impl<T: Config> OnRuntimeUpgrade for ContractMigrationV6<T> {
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade() -> Result<(), &'static str> {
-        let pre_contract_counts = Self::get_temp_storage("pre_contract_count").unwrap_or(0u64);
+        let expected_contract_count_after_migration = Self::get_temp_storage("expected_contract_count_after_migration").unwrap_or(0u64);
         let post_contract_counts = ContractsV7::<T>::iter().count().saturated_into::<u64>();
-        assert!(
-            post_contract_counts >= pre_contract_counts,
-            "This migration should result in the same amount of contracts or more!"
+        assert_eq!(post_contract_counts,
+            expected_contract_count_after_migration, 
+            "This migration failed: expectation did not equal the actual contract count!"
         );
         post_migration_checks::<T>();
         info!(
-            "👥  Smart Contract pallet to {:?} passes POST migrate checks ✅: {:?} contracts",
+            "👥  Smart Contract pallet to {:?} passes POST migrate checks ✅",
             PalletVersion::<T>::get(),
-            post_contract_counts,
         );
 
         Ok(())
@@ -167,44 +173,23 @@ impl<T: Config> OnRuntimeUpgrade for ContractMigrationV6<T> {
 pub fn post_migration_checks<T: Config>() {
     // lets check the contracts
     let mut count = 0;
+    let mut deployments_count = 0;
     for (_, contract) in ContractsV7::<T>::iter() {
+        assert!(
+            is_in_contracts_to_bill::<T>(contract.contract_id), 
+            "Contract with id {:?} should be in ContractsToBill!", 
+            contract.contract_id
+        );
         match contract.contract_type {
-            ContractData::NameContract(_) => {
-                assert!(
-                    is_in_contracts_to_bill::<T>(contract.contract_id), 
-                    "Name Contract with id {:?} should be in ContractsToBill!", 
-                    contract.contract_id
-                );
-            }
-            ContractData::Deployment(dc) => {
-                assert!(
-                    !is_in_contracts_to_bill::<T>(contract.contract_id), 
-                    "Deployment contract with id {:?} should not be in ContractsToBill!", 
-                    contract.contract_id
-                );
-                assert!(
-                    ContractsV7::<T>::contains_key(dc.capacity_reservation_id),
-                    "Migration failure! Capacity Reservation Contract with id {:?} not found!",
-                    dc.capacity_reservation_id
-                );
-            }
+            ContractData::NameContract(_) => { }
             ContractData::CapacityReservationContract(crc) => {
-                assert!(
-                    is_in_contracts_to_bill::<T>(contract.contract_id), 
-                    "Capacity Reservation Contract with id {:?} should be in ContractsToBill!", 
-                    contract.contract_id
-                );
                 let mut resources_check = Resources::empty();
                 let mut pub_ips = 0;
-                for dc_id in crc.deployment_contracts {
-                    let ctr = ContractsV7::<T>::get(dc_id).unwrap();
-                    let dc = match ctr.contract_type {
-                        ContractData::Deployment(dc) => Some(dc),
-                        _ => None,
-                    }
-                    .unwrap();
-                    resources_check.add(&dc.resources);
-                    pub_ips += dc.public_ips;
+                deployments_count += crc.deployments.len();
+                for d_id in crc.deployments {
+                    let deployment = Deployments::<T>::get(d_id).unwrap();
+                    resources_check.add(&deployment.resources);
+                    pub_ips += deployment.public_ips;
                 }
                 assert_eq!(crc.resources.used_resources, resources_check, 
                     "Migration failure! The used resources of capacity reservation contract with id {:?} are incorrect!",
@@ -220,6 +205,16 @@ pub fn post_migration_checks<T: Config>() {
         count += 1; 
     }
     info!("Checked the migration of {:?} contracts. All good ✅", count);
+
+    // lets check the deployments
+    assert_eq!(deployments_count, Deployments::<T>::iter().count(), "Migration failure! The amount of deployments doesn't equal the deployment ids found in the capacity reservations!");
+    for (_, deployment) in Deployments::<T>::iter() {
+        assert!(
+            ContractsV7::<T>::contains_key(deployment.capacity_reservation_id),
+            "Migration failure! Capacity Reservation Contract with id {:?} not found!",
+            deployment.capacity_reservation_id
+        );
+    }
 
     // check node resources
     count = 0;
@@ -264,6 +259,7 @@ pub fn migrate_to_version_7<T: Config>() -> frame_support::weights::Weight {
     let mut total_reads = 0;
     let mut total_writes = 0;
     let mut contracts: BTreeMap<u64, Contract<T>> = BTreeMap::new();
+
     let (mut bill_index_per_contract_id, reads) = get_bill_index_per_contract_id::<T>();
     total_reads += reads;
 
@@ -320,33 +316,6 @@ pub fn write_contracts_to_bill_at<T: Config>(
     (1, writes)
 }
 
-pub fn remove_deployment_contracts_from_contracts_to_bill<T: Config>(
-    contracts: &BTreeMap<u64, Contract<T>>,
-) -> (u32, u32) {
-    let mut writes = 0;
-    // we only bill capacity reservation contracts and name contracts
-    for index in 0..BillingFrequency::<T>::get() {
-        let mut contract_ids = ContractsToBillAt::<T>::get(index);
-        let mut modified = false;
-        contract_ids.retain(|id| {
-            if let Some(c) = contracts.get(id) {
-                let res = !matches!(c.contract_type, ContractData::Deployment(_));
-                modified |= res;
-                res
-            } else {
-                // some contracts are still in contracts to bill but have been removed already
-                // keep them as the chain will remove them and log stuff
-                true
-            }
-        });
-        if modified {
-            ContractsToBillAt::<T>::insert(index, &contract_ids);
-            writes += 1;
-        }
-    }
-    (1, writes)
-}
-
 pub fn translate_contract_objects<T: Config>(
     contracts: &mut BTreeMap<u64, Contract<T>>,
     bill_index_per_contract_id: &mut BTreeMap<u64, u64>,
@@ -356,29 +325,50 @@ pub fn translate_contract_objects<T: Config>(
     let mut crc_changes: BTreeMap<u64, ContractChanges<T>> = BTreeMap::new();
     let mut node_changes: BTreeMap<u32, NodeChanges> = BTreeMap::new();
 
+    // DeploymentID gets value of ContractID as we will convert the existing Node Contracts to Deployments and they will take over their id
+    DeploymentID::<T>::put(ContractID::<T>::get());
+    reads += 1;
+    writes +=1;
+
     for (k, ctr) in Contracts::<T>::drain() {
         reads += 1;
         let contract_type = match ctr.contract_type {
             deprecated::ContractData::NodeContract(ref nc) => {
                 let used_resources = NodeContractResources::<T>::get(ctr.contract_id).used;
-                let mut crc_id = ActiveRentContractForNode::<T>::get(nc.node_id).unwrap_or(0);
+                // the capacity reservation id is either the id of the existing rent contract (which will become a capacity reservation contract) 
+                // or we have to transform this contract into a capacity reservation contract and take over its id
+                let crc_id = ActiveRentContractForNode::<T>::get(nc.node_id).unwrap_or(ctr.contract_id);
                 reads += 2;
-                // if there is no rent contract for it create a capacity reservation contract that consumes the required resources
-                // else use the rent contract id as capacity reservation contract id
-                if crc_id == 0 {
-                    let billing_index = bill_index_per_contract_id
-                        .get(&ctr.contract_id)
-                        .unwrap_or(&0);
-                    let (id, crc) = create_capacity_reservation::<T>(
-                        nc.node_id,
-                        ctr.twin_id,
-                        ctr.state.clone(),
-                        used_resources,
-                        ctr.solution_provider_id,
-                    );
-                    crc_id = id;
-                    contracts.insert(crc_id, crc);
-                    bill_index_per_contract_id.insert(crc_id, *billing_index);
+
+                // create the deployment it gets the node contracts' id as an id
+                // see https://github.com/threefoldtech/tfchain/discussions/509
+                let dc = Deployment {
+                    id: ctr.contract_id,
+                    twin_id: ctr.twin_id,
+                    capacity_reservation_id: crc_id,
+                    deployment_hash: nc.deployment_hash,
+                    deployment_data: nc.deployment_data.clone(),
+                    public_ips: nc.public_ips,
+                    public_ips_list: nc.public_ips_list.clone(),
+                    resources: used_resources,
+                };
+                Deployments::<T>::insert(ctr.contract_id, &dc);
+                writes += 1;
+
+                if crc_id == ctr.contract_id {
+                    // There is no rent contract for it here so create a capacity reservation contract that consumes the
+                    // required resource. The only deployment is the one created above. Also take the public ips from it.
+                    let capacity_reservation_contract = CapacityReservationContract {
+                            node_id: nc.node_id,
+                            deployments: vec![ctr.contract_id],
+                            public_ips: nc.public_ips,
+                            resources: ConsumableResources {
+                                total_resources: used_resources.clone(),
+                                used_resources: used_resources.clone(),
+                            },
+                            group_id: None,
+                        };
+                    // gather the node changes
                     node_changes.entry(nc.node_id).and_modify(|changes| {
                         changes.active_contracts.push(crc_id);
                         changes.used_resources.add(&used_resources);
@@ -387,68 +377,63 @@ pub fn translate_contract_objects<T: Config>(
                         used_resources: used_resources,
                         active_contracts: vec![crc_id],
                     });
-                }
-
-                // remove the contract id from the billing as we don't bill deployment contracts
-                bill_index_per_contract_id.remove(&ctr.contract_id);
-
-                // create the deployment contract
-                let dc = Deployment {
-                    capacity_reservation_id: crc_id,
-                    deployment_hash: nc.deployment_hash,
-                    deployment_data: nc.deployment_data.clone(),
-                    public_ips: nc.public_ips,
-                    public_ips_list: nc.public_ips_list.clone(),
-                    resources: used_resources,
-                };
-
-                // gather the capacity reservation contract changes for later so that we can modify them later
-                let billing_info_dc = ContractBillingInformationByID::<T>::get(ctr.contract_id);
-                let contract_lock_dc = ContractLock::<T>::get(ctr.contract_id);
-                reads += 2;
-                crc_changes
+                    Some(ContractData::CapacityReservationContract(capacity_reservation_contract))
+                } else {
+                    // There was already a rent contract which will be converted into a capacity reservation contract so
+                    // no need to transform this one in a capacity reservation contract. Gather the capacity reservation
+                    // contract changes for later. 
+                    // We have to merge the billing info and contract lock into the rent contracts' billing info and 
+                    // contract lock 
+                    let billing_info_nc = ContractBillingInformationByID::<T>::take(ctr.contract_id);
+                    let contract_lock_nc = ContractLock::<T>::take(ctr.contract_id);
+                    reads += 2;
+                    writes += 2;
+                    crc_changes
                     .entry(dc.capacity_reservation_id)
                     .and_modify(|changes| {
                         changes.used_resources.add(&dc.resources);
                         changes.public_ips += dc.public_ips;
-                        changes.deployment_contracts.push(ctr.contract_id);
+                        changes.deployments.push(ctr.contract_id);
                         changes.billing_info.previous_nu_reported +=
-                            billing_info_dc.previous_nu_reported;
+                        billing_info_nc.previous_nu_reported;
                         changes.billing_info.last_updated = max(
                             changes.billing_info.last_updated,
-                            billing_info_dc.last_updated,
+                            billing_info_nc.last_updated,
                         );
-                        changes.billing_info.amount_unbilled += billing_info_dc.amount_unbilled;
-                        changes.contract_lock.amount_locked += contract_lock_dc.amount_locked;
+                        changes.billing_info.amount_unbilled += billing_info_nc.amount_unbilled;
+                        changes.contract_lock.amount_locked += contract_lock_nc.amount_locked;
                         changes.contract_lock.lock_updated = max(
                             changes.contract_lock.lock_updated,
-                            contract_lock_dc.lock_updated,
+                            contract_lock_nc.lock_updated,
                         );
                         changes.contract_lock.cycles =
-                            max(changes.contract_lock.cycles, contract_lock_dc.cycles);
+                            max(changes.contract_lock.cycles, contract_lock_nc.cycles);
                     })
                     .or_insert(ContractChanges {
                         used_resources: dc.resources,
                         public_ips: dc.public_ips,
-                        deployment_contracts: vec![ctr.contract_id],
-                        billing_info: billing_info_dc,
-                        contract_lock: contract_lock_dc,
+                        deployments: vec![ctr.contract_id],
+                        billing_info: billing_info_nc,
+                        contract_lock: contract_lock_nc,
                     });
-
-                ContractData::Deployment(dc)
+                    // the rent contract should be remove from billing
+                    bill_index_per_contract_id.remove(&ctr.contract_id);
+                    None
+                }
             }
             deprecated::ContractData::NameContract(nc) => {
-                ContractData::NameContract(NameContract { name: nc.name })
+                Some(ContractData::NameContract(NameContract { name: nc.name }))
             }
             deprecated::ContractData::RentContract(ref rc) => {
                 let node = pallet_tfgrid::Nodes::<T>::get(rc.node_id).unwrap();
+                reads += 2;
                 let crc = CapacityReservationContract {
                     node_id: rc.node_id,
-                    deployment_contracts: vec![],
-                    public_ips: 0,
+                    deployments: vec![], // will be filled in later
+                    public_ips: 0,       // will be modified later
                     resources: ConsumableResources {
                         total_resources: node.resources.total_resources,
-                        used_resources: Resources::empty(),
+                        used_resources: Resources::empty(), // will be modified later
                     },
                     group_id: None,
                 };
@@ -464,19 +449,21 @@ pub fn translate_contract_objects<T: Config>(
                         active_contracts: vec![ctr.contract_id],
                     });
 
-                ContractData::CapacityReservationContract(crc)
+                Some(ContractData::CapacityReservationContract(crc))
             }
         };
-        let new_contract = Contract {
-            version: CONTRACT_VERSION,
-            state: ctr.state,
-            contract_id: ctr.contract_id,
-            twin_id: ctr.twin_id,
-            contract_type: contract_type,
-            solution_provider_id: ctr.solution_provider_id,
-        };
-        info!("Contract: {:?} succesfully migrated", k);
-        contracts.insert(ctr.contract_id, new_contract);
+        if let Some(contract_type) = contract_type {
+            let new_contract = Contract {
+                version: CONTRACT_VERSION,
+                state: ctr.state,
+                contract_id: ctr.contract_id,
+                twin_id: ctr.twin_id,
+                contract_type: contract_type,
+                solution_provider_id: ctr.solution_provider_id,
+            };
+            info!("Contract: {:?} succesfully migrated", k);
+            contracts.insert(ctr.contract_id, new_contract);
+        }
     }
 
     frame_support::migration::remove_storage_prefix(
@@ -500,7 +487,7 @@ pub fn translate_contract_objects<T: Config>(
         .unwrap();
         crc.resources.used_resources = contract_changes.used_resources;
         crc.public_ips = contract_changes.public_ips;
-        crc.deployment_contracts = contract_changes.deployment_contracts;
+        crc.deployments = contract_changes.deployments;
         crc_contract.contract_type = ContractData::CapacityReservationContract(crc);
 
         ContractBillingInformationByID::<T>::insert(contract_id, contract_changes.billing_info);
@@ -557,39 +544,4 @@ pub fn find_bill_index<T: Config>(contract_id: u64) -> (Option<u64>, u32) {
     }
     info!("Reads for finding bill index {:?}", reads);
     (None, reads)
-}
-
-pub fn create_capacity_reservation<T: Config>(
-    node_id: u32,
-    twin_id: u32,
-    state: ContractState,
-    resources: Resources,
-    solution_provider_id: Option<u64>,
-) -> (u64, Contract<T>) {
-    let mut ctr_id = ContractID::<T>::get();
-    ctr_id = ctr_id + 1;
-
-    let capacity_reservation_contract = CapacityReservationContract {
-        node_id: node_id,
-        deployment_contracts: vec![],
-        public_ips: 0,
-        resources: ConsumableResources {
-            total_resources: resources.clone(),
-            used_resources: resources.clone(),
-        },
-        group_id: None,
-    };
-
-    let contract = Contract::<T> {
-        version: CONTRACT_VERSION,
-        state: state,
-        contract_id: ctr_id,
-        twin_id: twin_id,
-        contract_type: ContractData::CapacityReservationContract(capacity_reservation_contract),
-        solution_provider_id: solution_provider_id,
-    };
-
-    ContractID::<T>::put(ctr_id);
-
-    (ctr_id, contract)
 }

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -1652,7 +1652,7 @@ fn test_create_deployment_using_someone_elses_capacity_reservation_contract_fail
                 get_resources(),
                 1,
             ),
-            Error::<TestRuntime>::NotAuthorizedToCreateDeploymentContract
+            Error::<TestRuntime>::TwinNotAuthorized
         );
     })
 }

--- a/substrate-node/pallets/pallet-smart-contract/src/types.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/types.rs
@@ -62,7 +62,6 @@ impl<T: Config> Contract<T> {
     pub fn get_node_id(&self) -> u32 {
         match self.contract_type.clone() {
             ContractData::CapacityReservationContract(c) => c.node_id,
-            ContractData::DeploymentContract(_) => 0,
             ContractData::NameContract(_) => 0,
         }
     }
@@ -76,13 +75,15 @@ pub struct CapacityReservationContract {
     pub resources: ConsumableResources,
     pub group_id: Option<u32>,
     pub public_ips: u32,
-    pub deployment_contracts: Vec<u64>,
+    pub deployments: Vec<u64>,
 }
 
 #[derive(Clone, Eq, PartialEq, RuntimeDebugNoBound, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
 #[codec(mel_bound())]
-pub struct DeploymentContract<T: Config> {
+pub struct Deployment<T: Config> {
+    pub id: u64,
+    pub twin_id: u32,
     pub capacity_reservation_id: u64,
     // Hash of the deployment, set by the user
     // Max 32 bytes
@@ -121,7 +122,6 @@ pub struct RentContract {
 #[scale_info(skip_type_params(T))]
 #[codec(mel_bound())]
 pub enum ContractData<T: Config> {
-    DeploymentContract(DeploymentContract<T>),
     NameContract(NameContract<T>),
     CapacityReservationContract(CapacityReservationContract),
 }

--- a/substrate-node/pallets/pallet-smart-contract/src/weights.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/weights.rs
@@ -38,44 +38,46 @@
 // --template
 // ./.maintain/frame-weight-template.hbs
 
-
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{
+    traits::Get,
+    weights::{constants::RocksDbWeight, Weight},
+};
 use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet_smart_contract.
 pub trait WeightInfo {
-	fn create_node_contract() -> Weight;
-	fn add_reports() -> Weight;
+    fn create_node_contract() -> Weight;
+    fn add_reports() -> Weight;
 }
 
 /// Weights for pallet_smart_contract using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	fn create_node_contract() -> Weight {
-		(926_396_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes(8 as Weight))
-	}
-	fn add_reports() -> Weight {
-		(832_738_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(7 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-	}
+    fn create_node_contract() -> Weight {
+        (926_396_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(8 as Weight))
+            .saturating_add(T::DbWeight::get().writes(8 as Weight))
+    }
+    fn add_reports() -> Weight {
+        (832_738_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(7 as Weight))
+            .saturating_add(T::DbWeight::get().writes(1 as Weight))
+    }
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	fn create_node_contract() -> Weight {
-		(926_396_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(8 as Weight))
-	}
-	fn add_reports() -> Weight {
-		(832_738_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
-	}
+    fn create_node_contract() -> Weight {
+        (926_396_000 as Weight)
+            .saturating_add(RocksDbWeight::get().reads(8 as Weight))
+            .saturating_add(RocksDbWeight::get().writes(8 as Weight))
+    }
+    fn add_reports() -> Weight {
+        (832_738_000 as Weight)
+            .saturating_add(RocksDbWeight::get().reads(7 as Weight))
+            .saturating_add(RocksDbWeight::get().writes(1 as Weight))
+    }
 }

--- a/substrate-node/tests/TfChainClient.py
+++ b/substrate-node/tests/TfChainClient.py
@@ -517,7 +517,7 @@ class TfChainClient:
             contract_id=contract_id, port=port)
         self.bring_node_up(node_id=node_id, port=port)
 
-    def create_deployment_contract(self, capacity_reservation_id: int = 1, deployment_data: None | bytes = None,
+    def create_deployment(self, capacity_reservation_id: int = 1, deployment_data: None | bytes = None,
                                    deployment_hash: None | bytes = None, public_ips: int = 0,
                                    resources: dict = EMPTY_RESOURCES, contract_policy: int | None = None,
                                    port: int = DEFAULT_PORT, who: str = DEFAULT_SIGNER):
@@ -536,28 +536,42 @@ class TfChainClient:
             "contract_policy": contract_policy
         }
         call = substrate.compose_call(
-            "SmartContractModule", "create_deployment_contract", params)
+            "SmartContractModule", "create_deployment", params)
         expected_events = [{
             "module_id": "SmartContractModule",
-            "event_id": "ContractCreated"
+            "event_id": "DeploymentCreated"
         }]
         self._sign_extrinsic_submit_check_response(
             substrate, call, who, expected_events=expected_events)
 
-    def update_deployment_contract(self, contract_id: int = 1, deployment_data: bytes = randbytes(32),
+    def update_deployment(self, deployment_id: int = 1, deployment_data: bytes = randbytes(32),
                                    deployment_hash: bytes = randbytes(32), resources: None | dict = None,
                                    port: int = DEFAULT_PORT, who: str = DEFAULT_SIGNER):
         substrate = self._connect_to_server(f"ws://127.0.0.1:{port}")
 
-        call = substrate.compose_call("SmartContractModule", "update_deployment_contract", {
-            "contract_id": contract_id,
+        call = substrate.compose_call("SmartContractModule", "update_deployment", {
+            "deployment_id": deployment_id,
             "deployment_data": deployment_data,
             "deployment_hash": deployment_hash,
             "resources": None if resources is None else dict(resources),
         })
         expected_events = [{
             "module_id": "SmartContractModule",
-            "event_id": "ContractUpdated"
+            "event_id": "DeploymentUpdated"
+        }]
+        self._sign_extrinsic_submit_check_response(
+            substrate, call, who, expected_events=expected_events)
+    
+    def cancel_deployment(self, deployment_id: int = 1, port: int = DEFAULT_PORT, who: str = DEFAULT_SIGNER):
+        substrate = self._connect_to_server(f"ws://127.0.0.1:{port}")
+
+        call = substrate.compose_call("SmartContractModule", "cancel_deployment",
+                                      {
+                                          "deployment_id": deployment_id
+                                      })
+        expected_events = [{
+            "module_id": "SmartContractModule",
+            "event_id": f"DeploymentCanceled"
         }]
         self._sign_extrinsic_submit_check_response(
             substrate, call, who, expected_events=expected_events)
@@ -594,10 +608,6 @@ class TfChainClient:
         self._cancel_contract(contract_id=contract_id,
                               type="Name", port=port, who=who)
 
-    def cancel_deployment_contract(self, contract_id: int = 1, port: int = DEFAULT_PORT, who: str = DEFAULT_SIGNER):
-        self._cancel_contract(contract_id=contract_id,
-                              type="Deployment", port=port, who=who)
-
     def cancel_capacity_reservation_contract(self, contract_id: int = 1, port: int = DEFAULT_PORT, who: str = DEFAULT_SIGNER):
         node_id = self.get_node_id_from_capacity_reservation_contract(
             contract_id=contract_id, port=port)
@@ -612,12 +622,12 @@ class TfChainClient:
                 node["resources"]["used_resources"]["mru"] == 0:
             self.bring_node_down(node_id, nodes[0], port=port)
 
-    def add_nru_reports(self, contract_id: int = 1, nru: int = 1, port: int = DEFAULT_PORT, who: str = DEFAULT_SIGNER):
+    def add_nru_reports(self, deployment_id: int = 1, nru: int = 1, port: int = DEFAULT_PORT, who: str = DEFAULT_SIGNER):
         block_number = self.get_block_number(port=port)
         substrate = self._connect_to_server(f"ws://127.0.0.1:{port}")
 
         reports = [{
-            "contract_id": contract_id,
+            "contract_id": deployment_id,
             "nru": nru * GIGABYTE,
             "timestamp": block_number,
             "window": 6 * block_number

--- a/substrate-node/tests/integration_tests.robot
+++ b/substrate-node/tests/integration_tests.robot
@@ -316,7 +316,7 @@ Test Add Public Config On Node: Failure InvalidDomain
     
     
 
-Test Create Update Cancel Deployment Contract: Success
+Test Create Update Cancel Deployment: Success
     [Documentation]    Testing api calls (create, update, cancel) for managing a node contract
     Setup Multi Node Network    log_name=test_create_node_contract
 
@@ -337,7 +337,7 @@ Test Create Update Cancel Deployment Contract: Success
     ${policy} =     Capacity Reservation Policy Any    ${resources_cr}
     Create Capacity Reservation Contract    farm_id=${1}    policy=${policy}    who=Bob    port=9946
     ${resources_dc} =    Resources    hru=${256}    sru=${256}    cru=${2}    mru=${4} 
-    Create Deployment Contract    capacity_reservation_id=${1}    resources=${resources_dc}    public_ips=${1}    who=Bob    port=9946
+    Create Deployment    capacity_reservation_id=${1}    resources=${resources_dc}    public_ips=${1}    who=Bob    port=9946
 
     ${farm} =     Get Farm    ${1}
     Should Not Be Equal    ${farm}    ${None}    msg=Farm with id 1 doesn't exist
@@ -345,16 +345,16 @@ Test Create Update Cancel Deployment Contract: Success
     Length Should Be    ${farm}[public_ips]    1    msg=There should only be one public ip in public_ips
     Should Be Equal    ${farm}[public_ips][0][ip]    185.206.122.33/24    msg=The public ip address should be 185.206.122.33/24
     Should Be Equal    ${farm}[public_ips][0][gateway]    185.206.122.1    msg=The gateway should be 185.206.122.1
-    Should Be Equal    ${farm}[public_ips][0][contract_id]    ${2}    msg=The public ip was claimed in contract with id 1 while the farm contains a different contract id for it
+    Should Be Equal    ${farm}[public_ips][0][contract_id]    ${1}    msg=The public ip was claimed in deployment with id 1 while the farm contains a different contract id for it
 
     ${updated_resources} =    Resources    hru=${512}    sru=${128}    cru=${1}    mru=${6}
-    Update Deployment Contract    contract_id=${2}    resources=${updated_resources}    who=Bob    port=9946
+    Update Deployment    deployment_id=${1}    resources=${updated_resources}    who=Bob    port=9946
 
-    Cancel Deployment Contract    contract_id=${2}    who=Bob    port=9946
+    Cancel Deployment    deployment_id=${1}    who=Bob    port=9946
 
     Tear Down Multi Node Network
 
-Test Create Deployment Contract: Failure Not Enough Public Ips
+Test Create Deployment: Failure Not Enough Public Ips
     [Documentation]    Testing creating a node contract and requesting too much pub ips
     Setup Multi Node Network    log_name=test_create_node_contract_failure_notenoughpubips
 
@@ -366,7 +366,7 @@ Test Create Deployment Contract: Failure Not Enough Public Ips
     # let's request 2 public ips which should result in an error
     ${resources} =    Resources
     Run Keyword And Expect Error    *'FarmHasNotEnoughPublicIPs'*
-    ...    Create Deployment Contract    capacity_reservation_id=${1}    public_ips=${2}    resources=${resources}
+    ...    Create Deployment    capacity_reservation_id=${1}    public_ips=${2}    resources=${resources}
 
     Tear Down Multi Node Network
 
@@ -473,16 +473,16 @@ Test Billing
     ${resources_cr} =    Resources    hru=${512}    sru=${256}    cru=${4}    mru=${8}
     ${policy} =     Capacity Reservation Policy Any    ${resources_cr}
     Create Capacity Reservation Contract    farm_id=${1}    policy=${policy}    port=${9946}    who=Bob
-    # Let's create two deployment contracts (simulating two vms on the node) both taking half of the resources of the capacity reservation contract
+    # Let's create two deployments (simulating two vms on the node) both taking half of the resources of the capacity reservation contract
     ${resources_dc} =    Resources    hru=${256}    sru=${128}    cru=${2}    mru=${4}
-    Create Deployment Contract    capacity_reservation_id=${1}    resources=${resources_dc}   port=${9946}    who=Bob
-    Create Deployment Contract    capacity_reservation_id=${1}    resources=${resources_dc}    public_ips=1    port=${9946}    who=Bob
-    Add Nru Reports    contract_id=${2}    nru=${3}
+    Create Deployment    capacity_reservation_id=${1}    resources=${resources_dc}   port=${9946}    who=Bob
+    Create Deployment    capacity_reservation_id=${1}    resources=${resources_dc}    public_ips=1    port=${9946}    who=Bob
+    Add Nru Reports    deployment_id=${1}    nru=${3}
 
     # Let it run 6 blocks so that the user will be billed 1 time
     Wait X Blocks    ${6}
-    Cancel Deployment Contract    contract_id=${3}    who=Bob
-    Cancel Deployment Contract    contract_id=${2}    who=Bob
+    Cancel Deployment    deployment_id=${2}    who=Bob
+    Cancel Deployment    deployment_id=${1}    who=Bob
     Cancel Capacity Reservation Contract    contract_id=${1}    who=Bob
 
     # Balance should have decreased
@@ -523,12 +523,12 @@ Test Solution Provider
     ${policy} =    Capacity Reservation Policy Node    ${1}
     Create Capacity Reservation Contract    farm_id=${1}    policy=${policy}    solution_provider_id=${1}    port=9946    who=Bob
     ${resources} =    Resources    hru=${20}    sru=${20}    cru=${2}    mru=${4}
-    Create Deployment Contract    resources=${resources}    port=9946    who=Bob
-    Add Nru Reports    contract_id=${2}    nru=${3}
+    Create Deployment    resources=${resources}    port=9946    who=Bob
+    Add Nru Reports    deployment_id=${1}    nru=${3}
     # Wait 6 blocks: after 5 blocks Bob should be billed
     Wait X Blocks    ${6}
     # Cancel the contract so that the bill is distributed and so that the providers get their part
-    Cancel Deployment Contract    contract_id=${2}    who=Bob
+    Cancel Deployment    deployment_id=${1}    who=Bob
     Cancel Capacity Reservation Contract    contract_id=${1}    who=Bob
 
     # Verification: both providers should have received their part


### PR DESCRIPTION
Removes deployment contract type since it was not really a "contract" object at all.