### PR TITLE
Don't statically link libc

### DIFF
--- a/substrate-node/.cargo/config.toml
+++ b/substrate-node/.cargo/config.toml
@@ -1,0 +1,4 @@
+[build]
+# By default, on musl linux, statically linked binaries are produced.
+# Rocksdb doesn't like that
+rustflags = ["-C", "target-feature=-crt-static"]

--- a/substrate-node/.gitignore
+++ b/substrate-node/.gitignore
@@ -6,8 +6,5 @@
 
 .DS_Store
 
-# The cache for docker container dependency
-.cargo
-
 # The cache for chain data in container
 .local


### PR DESCRIPTION
this allows compilation of Rocksdb on musl linux