### PR TITLE
feat: rework serial validation on node

### DIFF
--- a/substrate-node/pallets/pallet-dao/src/lib.rs
+++ b/substrate-node/pallets/pallet-dao/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "128"]
 
-use pallet_tfgrid::pallet::{InterfaceOf, LocationOf, SerialNumberOf, TfgridNode};
+use pallet_tfgrid::pallet::{InterfaceOf, LocationOf, TfgridNode};
 use sp_runtime::traits::Hash;
 use sp_std::prelude::*;
 
@@ -69,7 +69,7 @@ pub mod pallet {
         type MinVetos: Get<u32>;
 
         type Tfgrid: Tfgrid<Self::AccountId, FarmName<Self>>;
-        type NodeChanged: ChangeNode<LocationOf<Self>, InterfaceOf<Self>, SerialNumberOf<Self>>;
+        type NodeChanged: ChangeNode<LocationOf<Self>, InterfaceOf<Self>>;
 
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
@@ -510,7 +510,7 @@ impl<T: Config> Pallet<T> {
     }
 }
 
-impl<T: Config> ChangeNode<LocationOf<T>, InterfaceOf<T>, SerialNumberOf<T>> for Pallet<T> {
+impl<T: Config> ChangeNode<LocationOf<T>, InterfaceOf<T>> for Pallet<T> {
     fn node_changed(old_node: Option<&TfgridNode<T>>, new_node: &TfgridNode<T>) {
         let new_node_weight = new_node.resources.get_node_weight();
         match old_node {

--- a/substrate-node/pallets/pallet-dao/src/mock.rs
+++ b/substrate-node/pallets/pallet-dao/src/mock.rs
@@ -7,7 +7,7 @@ use pallet_tfgrid::node::{CityName, CountryName};
 use pallet_tfgrid::{
     farm::FarmName,
     interface::{InterfaceIp, InterfaceMac, InterfaceName},
-    node::{Location, SerialNumber},
+    node::Location,
     terms_cond::TermsAndConditions,
     CityNameInput, CountryNameInput, DocumentHashInput, DocumentLinkInput, Gw4Input, Ip4Input,
     LatitudeInput, LongitudeInput, PkInput, RelayInput,
@@ -78,14 +78,13 @@ parameter_types! {
     pub const MinVetos: u32 = 2;
 }
 
-pub(crate) type Serial = pallet_tfgrid::pallet::SerialNumberOf<Test>;
 pub(crate) type Loc = pallet_tfgrid::pallet::LocationOf<Test>;
 pub(crate) type Interface = pallet_tfgrid::pallet::InterfaceOf<Test>;
 
 pub(crate) type TfgridNode = pallet_tfgrid::pallet::TfgridNode<Test>;
 
 pub struct NodeChanged;
-impl ChangeNode<Loc, Interface, Serial> for NodeChanged {
+impl ChangeNode<Loc, Interface> for NodeChanged {
     fn node_changed(old_node: Option<&TfgridNode>, new_node: &TfgridNode) {
         DaoModule::node_changed(old_node, new_node)
     }
@@ -129,7 +128,6 @@ pub(crate) type TestInterfaceIp = InterfaceIp<Test>;
 pub(crate) type TestCountryName = CountryName<Test>;
 pub(crate) type TestCityName = CityName<Test>;
 pub(crate) type TestLocation = Location<Test>;
-pub(crate) type TestSerialNumber = SerialNumber<Test>;
 
 impl pallet_tfgrid::Config for Test {
     type RuntimeEvent = RuntimeEvent;
@@ -149,7 +147,6 @@ impl pallet_tfgrid::Config for Test {
     type CountryName = TestCountryName;
     type CityName = TestCityName;
     type Location = TestLocation;
-    type SerialNumber = TestSerialNumber;
 }
 
 impl pallet_timestamp::Config for Test {

--- a/substrate-node/pallets/pallet-smart-contract/src/lib.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/lib.rs
@@ -17,7 +17,7 @@ use frame_system::{
 pub use pallet::*;
 use pallet_authorship;
 use pallet_tfgrid;
-use pallet_tfgrid::pallet::{InterfaceOf, LocationOf, SerialNumberOf, TfgridNode};
+use pallet_tfgrid::pallet::{InterfaceOf, LocationOf, TfgridNode};
 use pallet_tfgrid::types as pallet_tfgrid_types;
 use pallet_timestamp as timestamp;
 use sp_core::crypto::KeyTypeId;
@@ -228,7 +228,7 @@ pub mod pallet {
         type DistributionFrequency: Get<u16>;
         type GracePeriod: Get<u64>;
         type WeightInfo: WeightInfo;
-        type NodeChanged: ChangeNode<LocationOf<Self>, InterfaceOf<Self>, SerialNumberOf<Self>>;
+        type NodeChanged: ChangeNode<LocationOf<Self>, InterfaceOf<Self>>;
         type PublicIpModifier: PublicIpModifier;
         type AuthorityId: AppCrypto<Self::Public, Self::Signature>;
         type Call: From<Call<Self>>;
@@ -2262,7 +2262,7 @@ impl<T: Config> Pallet<T> {
     }
 }
 
-impl<T: Config> ChangeNode<LocationOf<T>, InterfaceOf<T>, SerialNumberOf<T>> for Pallet<T> {
+impl<T: Config> ChangeNode<LocationOf<T>, InterfaceOf<T>> for Pallet<T> {
     fn node_changed(_node: Option<&TfgridNode<T>>, _new_node: &TfgridNode<T>) {}
 
     fn node_deleted(node: &TfgridNode<T>) {

--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -14,8 +14,8 @@ use frame_system::EnsureRoot;
 use pallet_tfgrid::{
     farm::FarmName,
     interface::{InterfaceIp, InterfaceMac, InterfaceName},
+    node::Location,
     node::{CityName, CountryName},
-    node::{Location, SerialNumber},
     terms_cond::TermsAndConditions,
     CityNameInput, CountryNameInput, DocumentHashInput, DocumentLinkInput, Gw4Input, Ip4Input,
     LatitudeInput, LongitudeInput, PkInput, RelayInput,
@@ -167,14 +167,13 @@ impl pallet_balances::Config for TestRuntime {
     type WeightInfo = pallet_balances::weights::SubstrateWeight<TestRuntime>;
 }
 
-pub(crate) type Serial = pallet_tfgrid::pallet::SerialNumberOf<TestRuntime>;
 pub(crate) type Loc = pallet_tfgrid::pallet::LocationOf<TestRuntime>;
 pub(crate) type Interface = pallet_tfgrid::pallet::InterfaceOf<TestRuntime>;
 
 pub(crate) type TfgridNode = pallet_tfgrid::pallet::TfgridNode<TestRuntime>;
 
 pub struct NodeChanged;
-impl ChangeNode<Loc, Interface, Serial> for NodeChanged {
+impl ChangeNode<Loc, Interface> for NodeChanged {
     fn node_changed(_old_node: Option<&TfgridNode>, _new_node: &TfgridNode) {}
     fn node_deleted(node: &TfgridNode) {
         SmartContractModule::node_deleted(node);
@@ -206,7 +205,6 @@ pub(crate) type TestInterfaceIp = InterfaceIp<TestRuntime>;
 pub(crate) type TestCountryName = CountryName<TestRuntime>;
 pub(crate) type TestCityName = CityName<TestRuntime>;
 pub(crate) type TestLocation = Location<TestRuntime>;
-pub(crate) type TestSerialNumber = SerialNumber<TestRuntime>;
 
 impl pallet_tfgrid::Config for TestRuntime {
     type RuntimeEvent = RuntimeEvent;
@@ -226,7 +224,6 @@ impl pallet_tfgrid::Config for TestRuntime {
     type CountryName = TestCountryName;
     type CityName = TestCityName;
     type Location = TestLocation;
-    type SerialNumber = TestSerialNumber;
 }
 
 impl pallet_tft_price::Config for TestRuntime {

--- a/substrate-node/pallets/pallet-tfgrid/src/lib.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/lib.rs
@@ -542,8 +542,6 @@ pub mod pallet {
         InvalidCityName,
         InvalidCountryCityPair,
 
-        SerialNumberTooShort,
-        SerialNumberTooLong,
         InvalidSerialNumber,
 
         DocumentLinkInputTooShort,
@@ -982,7 +980,7 @@ pub mod pallet {
                 Error::<T>::NodeWithTwinIdExists
             );
 
-            let s = match serial_number {
+            let serial_number = match serial_number {
                 Some(serial) => Some(Self::get_serial_number(serial)?),
                 None => None,
             };
@@ -1010,7 +1008,7 @@ pub mod pallet {
                 certification: NodeCertification::default(),
                 secure_boot,
                 virtualized,
-                serial_number: s,
+                serial_number,
                 connection_price: ConnectionPrice::<T>::get(),
             };
 
@@ -1063,7 +1061,7 @@ pub mod pallet {
 
             ensure!(Farms::<T>::contains_key(farm_id), Error::<T>::FarmNotExists);
 
-            let s = match serial_number {
+            let serial_number = match serial_number {
                 Some(serial) => Some(Self::get_serial_number(serial)?),
                 None => None,
             };
@@ -1103,7 +1101,7 @@ pub mod pallet {
             stored_node.interfaces = node_interfaces;
             stored_node.secure_boot = secure_boot;
             stored_node.virtualized = virtualized;
-            stored_node.serial_number = s;
+            stored_node.serial_number = serial_number;
 
             // override node in storage
             Nodes::<T>::insert(stored_node.id, &stored_node);

--- a/substrate-node/pallets/pallet-tfgrid/src/migrations/mod.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/migrations/mod.rs
@@ -1,7 +1,7 @@
 pub mod types;
-pub mod v10;
-pub mod v11;
-pub mod v12;
-pub mod v13;
+//pub mod v10;
+//pub mod v11;
+//pub mod v12;
+//pub mod v13;
 pub mod v14;
 pub mod v15;

--- a/substrate-node/pallets/pallet-tfgrid/src/mock.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/mock.rs
@@ -3,7 +3,7 @@ use crate::{
     farm::FarmName,
     interface::{InterfaceIp, InterfaceMac, InterfaceName},
     mock::sp_api_hidden_includes_construct_runtime::hidden_include::traits::GenesisBuild,
-    node::{CityName, CountryName, Location, SerialNumber},
+    node::{CityName, CountryName, Location},
     terms_cond::TermsAndConditions,
     weights, CityNameInput, Config, CountryNameInput, DocumentHashInput, DocumentLinkInput,
     DomainInput, FarmNameInput, Gw4Input, Gw6Input, InterfaceIpInput, InterfaceMacInput,
@@ -79,14 +79,13 @@ impl frame_system::Config for TestRuntime {
     type MaxConsumers = ConstU32<16>;
 }
 
-pub(crate) type Serial = crate::SerialNumberOf<TestRuntime>;
 pub(crate) type Loc = crate::LocationOf<TestRuntime>;
 pub(crate) type Interface = crate::InterfaceOf<TestRuntime>;
 
 pub(crate) type TfgridNode = crate::TfgridNode<TestRuntime>;
 
 pub struct NodeChanged;
-impl tfchain_support::traits::ChangeNode<Loc, Interface, Serial> for NodeChanged {
+impl tfchain_support::traits::ChangeNode<Loc, Interface> for NodeChanged {
     fn node_changed(_old_node: Option<&TfgridNode>, _new_node: &TfgridNode) {}
     fn node_deleted(_node: &TfgridNode) {}
 }
@@ -114,7 +113,6 @@ pub(crate) type TestInterfaceIp = InterfaceIp<TestRuntime>;
 pub(crate) type TestCountryName = CountryName<TestRuntime>;
 pub(crate) type TestCityName = CityName<TestRuntime>;
 pub(crate) type TestLocation = Location<TestRuntime>;
-pub(crate) type TestSerialNumber = SerialNumber<TestRuntime>;
 
 impl Config for TestRuntime {
     type RuntimeEvent = RuntimeEvent;
@@ -134,7 +132,6 @@ impl Config for TestRuntime {
     type CountryName = TestCountryName;
     type CityName = TestCityName;
     type Location = TestLocation;
-    type SerialNumber = TestSerialNumber;
 }
 
 parameter_types! {

--- a/substrate-node/pallets/pallet-tfgrid/src/tests.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/tests.rs
@@ -1421,7 +1421,7 @@ fn create_node_with_same_pubkey_fails() {
                 bounded_vec![],
                 true,
                 true,
-                None,
+                Some(b"serial number 123 / ( +".to_vec().try_into().unwrap()),
             ),
             Error::<TestRuntime>::NodeWithTwinIdExists
         );

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -314,14 +314,13 @@ impl pallet_sudo::Config for Runtime {
     type RuntimeCall = RuntimeCall;
 }
 
-pub type Serial = pallet_tfgrid::pallet::SerialNumberOf<Runtime>;
 pub type Loc = pallet_tfgrid::pallet::LocationOf<Runtime>;
 pub type Interface = pallet_tfgrid::pallet::InterfaceOf<Runtime>;
 
 pub type TfgridNode = pallet_tfgrid::pallet::TfgridNode<Runtime>;
 
 pub struct NodeChanged;
-impl ChangeNode<Loc, Interface, Serial> for NodeChanged {
+impl ChangeNode<Loc, Interface> for NodeChanged {
     fn node_changed(old_node: Option<&TfgridNode>, new_node: &TfgridNode) {
         Dao::node_changed(old_node, new_node)
     }
@@ -364,7 +363,6 @@ impl pallet_tfgrid::Config for Runtime {
     type CountryName = pallet_tfgrid::node::CountryName<Runtime>;
     type CityName = pallet_tfgrid::node::CityName<Runtime>;
     type Location = pallet_tfgrid::node::Location<Runtime>;
-    type SerialNumber = pallet_tfgrid::node::SerialNumber<Runtime>;
 }
 
 parameter_types! {

--- a/substrate-node/support/src/traits.rs
+++ b/substrate-node/support/src/traits.rs
@@ -1,4 +1,3 @@
-
 use crate::types::PublicIP;
 pub trait Tfgrid<AccountId, Name> {
     fn get_farm(farm_id: u32) -> Option<super::types::Farm<Name>>;
@@ -6,12 +5,12 @@ pub trait Tfgrid<AccountId, Name> {
     fn is_twin_owner(twin_id: u32, who: AccountId) -> bool;
 }
 
-pub trait ChangeNode<Loc, If, Serial> {
+pub trait ChangeNode<Loc, If> {
     fn node_changed(
-        node: Option<&super::types::Node<Loc, If, Serial>>,
-        new_node: &super::types::Node<Loc, If, Serial>,
+        node: Option<&super::types::Node<Loc, If>>,
+        new_node: &super::types::Node<Loc, If>,
     );
-    fn node_deleted(node: &super::types::Node<Loc, If, Serial>);
+    fn node_deleted(node: &super::types::Node<Loc, If>);
 }
 
 pub trait PublicIpModifier {

--- a/substrate-node/support/src/types.rs
+++ b/substrate-node/support/src/types.rs
@@ -78,6 +78,8 @@ pub struct FarmingPolicyLimit {
     pub node_certification: bool,
 }
 
+pub type SerialNumber = BoundedVec<u8, ConstU32<{ MAX_SERIAL_NUMBER_LENGTH }>>;
+
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default, Debug, TypeInfo)]
 pub struct Node<Location, If> {
     pub version: u32,
@@ -94,7 +96,7 @@ pub struct Node<Location, If> {
     pub certification: NodeCertification,
     pub secure_boot: bool,
     pub virtualized: bool,
-    pub serial_number: Option<BoundedVec<u8, ConstU32<MAX_SERIAL_NUMBER_LENGTH>>>,
+    pub serial_number: Option<SerialNumber>,
     pub connection_price: u32,
 }
 

--- a/substrate-node/support/src/types.rs
+++ b/substrate-node/support/src/types.rs
@@ -12,6 +12,7 @@ pub const MAX_GW4_LENGTH: u32 = 15;
 pub const MAX_IP6_LENGTH: u32 = 43;
 pub const MAX_GW6_LENGTH: u32 = 39;
 pub const MAX_DOMAIN_NAME_LENGTH: u32 = 128;
+pub const MAX_SERIAL_NUMBER_LENGTH: u32 = 128;
 
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default, Debug, TypeInfo, MaxEncodedLen,
@@ -78,7 +79,7 @@ pub struct FarmingPolicyLimit {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default, Debug, TypeInfo)]
-pub struct Node<Location, If, SerialNumber> {
+pub struct Node<Location, If> {
     pub version: u32,
     pub id: u32,
     pub farm_id: u32,
@@ -93,7 +94,7 @@ pub struct Node<Location, If, SerialNumber> {
     pub certification: NodeCertification,
     pub secure_boot: bool,
     pub virtualized: bool,
-    pub serial_number: Option<SerialNumber>,
+    pub serial_number: Option<BoundedVec<u8, ConstU32<MAX_SERIAL_NUMBER_LENGTH>>>,
     pub connection_price: u32,
 }
 


### PR DESCRIPTION
Removes serial as a generic on the Node struct, also removes character validation (keep max length of 128 bytes). 